### PR TITLE
Fix service account name to keystone-operator

### DIFF
--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -30,7 +30,7 @@ func BootstrapJob(cr *comv1.KeystoneAPI, configMapName string) *batchv1.Job {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy:      "OnFailure",
-					ServiceAccountName: "keystone",
+					ServiceAccountName: "keystone-operator",
 					Containers: []corev1.Container{
 						{
 							Name:    configMapName + "-bootstrap",

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -33,7 +33,7 @@ func DbSyncJob(cr *comv1.KeystoneAPI, cmName string) *batchv1.Job {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy:      "OnFailure",
-					ServiceAccountName: "keystone",
+					ServiceAccountName: "keystone-operator",
 					Containers: []corev1.Container{
 						{
 							Name:  "keystone-db-sync",

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -29,7 +29,7 @@ func Deployment(cr *comv1.KeystoneAPI, cmName string, configHash string) *appsv1
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "keystone",
+					ServiceAccountName: "keystone-operator",
 					Containers: []corev1.Container{
 						{
 							Name:  "keystone-api",


### PR DESCRIPTION
As specified in deploy/service_account.yaml, the service account name
should be keystone-operator everywhere it is used.