### PR TITLE
Use train image for keystone

### DIFF
--- a/deploy/crds/keystone.openstack.org_keystoneapis_cr.yaml
+++ b/deploy/crds/keystone.openstack.org_keystoneapis_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keystone
 spec:
   adminPassword: foobar123
-  containerImage: docker.io/tripleostein/centos-binary-keystone:current-tripleo
+  containerImage: docker.io/tripleotrain/centos-binary-keystone:current-tripleo
   replicas: 1
   databasePassword: foobar123
   databaseHostname: openstack-db-mariadb


### PR DESCRIPTION
The train image works also and is consistent with the rest of the
openstack-k8s work.