### PR TITLE
Wait for Keystone bootstrap in endpoint/service controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/tools v0.0.0-20200721163027-5ea363182e19 // indirect
+	golang.org/x/tools v0.0.0-20200722181740-bd1e9de8d890 // indirect
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1090,6 +1090,8 @@ golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e h1:qCZ8SbsZMjT0OuDPCEBxgLZ
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200721163027-5ea363182e19 h1:t3lbB+Vz9YaLx0iZAKJjjI0sRZnpsC4k16wKVgwiehY=
 golang.org/x/tools v0.0.0-20200721163027-5ea363182e19/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200722181740-bd1e9de8d890 h1:Fwx9UWtbBIMKQ+hdL1ltEyRaLkbpvN+ii5XUAz9o2n8=
+golang.org/x/tools v0.0.0-20200722181740-bd1e9de8d890/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/keystone/api.go
+++ b/pkg/keystone/api.go
@@ -1,0 +1,18 @@
+package keystone
+
+import (
+	comv1 "github.com/openstack-k8s-operators/keystone-operator/pkg/apis/keystone/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// API func
+func API(nameSpace string, name string) *comv1.KeystoneAPI {
+
+	keystoneAPI := &comv1.KeystoneAPI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: nameSpace,
+		},
+	}
+	return keystoneAPI
+}


### PR DESCRIPTION
The endpoint and service controllers are updated so that they ensure the
keystone boostrap job is complete by checking the bootstrap hash from
KeystoneAPI.Status.