### PR TITLE
Add anyuid scc to serviceRules

### DIFF
--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -341,6 +341,20 @@ func getServiceRules() *[]rbacv1.PolicyRule {
 				"*",
 			},
 		},
+		{
+			APIGroups: []string{
+				"security.openshift.io",
+			},
+			Resources: []string{
+				"securitycontextconstraints",
+			},
+			ResourceNames: []string{
+				"anyuid",
+			},
+			Verbs: []string{
+				"use",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Jobs run as user 0 which required the as anyuid SCC. This adds it
to the serviceRules for the keystone user.