### PR TITLE
Align DB default service name

### DIFF
--- a/deploy/crds/keystone.openstack.org_keystoneapis_cr.yaml
+++ b/deploy/crds/keystone.openstack.org_keystoneapis_cr.yaml
@@ -7,7 +7,7 @@ spec:
   containerImage: docker.io/tripleotrain/centos-binary-keystone:current-tripleo
   replicas: 1
   databasePassword: foobar123
-  databaseHostname: openstack-db-mariadb
+  databaseHostname: mariadb
   # used to create the DB schema
   databaseAdminUsername: root
   databaseAdminPassword: foobar123


### PR DESCRIPTION
The mariadb-operator calls the service then name of the CR, which
we have as 'mariadb' in our dev environment.