### PR TITLE
Use MariaDBSchema CRD to create DB schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ spec:
   databaseHostname: openstack-db-mariadb
   # used for keystone-manage bootstrap endpoints
   apiEndpoint: http://keystone-test.apps.test.dprince/
-  # used to create the DB schema
-  databaseAdminUsername: root
-  databaseAdminPassword: foobar123
-  mysqlContainerImage: docker.io/tripleomaster/centos-binary-mariadb:current-tripleo
 ``` 
 
 # Design

--- a/deploy/crds/keystone.openstack.org_keystoneapis_cr.yaml
+++ b/deploy/crds/keystone.openstack.org_keystoneapis_cr.yaml
@@ -7,8 +7,4 @@ spec:
   containerImage: docker.io/tripleotrain/centos-binary-keystone:current-tripleo
   replicas: 1
   databasePassword: foobar123
-  databaseHostname: openstack-db-mariadb
-  # used to create the DB schema
-  databaseAdminUsername: root
-  databaseAdminPassword: foobar123
-  mysqlContainerImage: docker.io/tripleomaster/centos-binary-mariadb:current-tripleo
+  databaseHostname: mariadb

--- a/deploy/crds/keystone.openstack.org_keystoneapis_crd.yaml
+++ b/deploy/crds/keystone.openstack.org_keystoneapis_crd.yaml
@@ -37,20 +37,11 @@ spec:
             containerImage:
               description: Keystone Container Image URL
               type: string
-            databaseAdminPassword:
-              description: Database Admin Password
-              type: string
-            databaseAdminUsername:
-              description: Database Admin Username
-              type: string
             databaseHostname:
               description: Keystone Database Hostname String
               type: string
             databasePassword:
               description: Keystone Database Password String
-              type: string
-            mysqlContainerImage:
-              description: Mysql Container Image URL (used for database syncing)
               type: string
             replicas:
               description: Replicas

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,8 @@ module github.com/openstack-k8s-operators/keystone-operator
 go 1.13
 
 require (
-	github.com/RHsyseng/operator-utils v0.0.0-20200417214513-7aac0c82a293
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0
-	github.com/go-openapi/spec v0.19.4
 	github.com/gophercloud/gophercloud v0.6.0
 	github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
 	github.com/openstack-k8s-operators/lib-common v0.0.0-20200506095056-36244492b7a8
@@ -19,7 +16,6 @@ require (
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	sigs.k8s.io/controller-runtime v0.5.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -73,7 +73,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RHsyseng/operator-utils v0.0.0-20200417214513-7aac0c82a293/go.mod h1:E+hCtYz+9UsXfAGnRjX2LGuaa5gSGNKHCVTmGZR79vY=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -518,6 +517,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -1092,8 +1092,6 @@ golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e h1:qCZ8SbsZMjT0OuDPCEBxgLZic4NMj8Gj4vNXiTVRAaA=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/tools v0.0.0-20200721163027-5ea363182e19 h1:t3lbB+Vz9YaLx0iZAKJjjI0sRZnpsC4k16wKVgwiehY=
-golang.org/x/tools v0.0.0-20200721163027-5ea363182e19/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200722181740-bd1e9de8d890 h1:Fwx9UWtbBIMKQ+hdL1ltEyRaLkbpvN+ii5XUAz9o2n8=
 golang.org/x/tools v0.0.0-20200722181740-bd1e9de8d890/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/apis/keystone/v1/keystoneapi_types.go
+++ b/pkg/apis/keystone/v1/keystoneapi_types.go
@@ -13,12 +13,6 @@ type KeystoneAPISpec struct {
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 	// Keystone Container Image URL
 	ContainerImage string `json:"containerImage,omitempty"`
-	// Mysql Container Image URL (used for database syncing)
-	MysqlContainerImage string `json:"mysqlContainerImage,omitempty"`
-	// Database Admin Username
-	DatabaseAdminUsername string `json:"databaseAdminUsername,omitempty"`
-	// Database Admin Password
-	DatabaseAdminPassword string `json:"databaseAdminPassword,omitempty"`
 	// Keystone API Admin Password
 	AdminPassword string `json:"adminPassword,omitempty"`
 	// Replicas

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -2,22 +2,14 @@ package keystone
 
 import (
 	comv1 "github.com/openstack-k8s-operators/keystone-operator/pkg/apis/keystone/v1"
-	util "github.com/openstack-k8s-operators/lib-common/pkg/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type dbCreateOptions struct {
-	DatabasePassword      string
-	DatabaseHostname      string
-	DatabaseAdminUsername string
-}
-
 // DbSyncJob func
 func DbSyncJob(cr *comv1.KeystoneAPI, cmName string) *batchv1.Job {
 
-	opts := dbCreateOptions{cr.Spec.DatabasePassword, cr.Spec.DatabaseHostname, cr.Spec.DatabaseAdminUsername}
 	runAsUser := int64(0)
 
 	labels := map[string]string{
@@ -52,19 +44,6 @@ func DbSyncJob(cr *comv1.KeystoneAPI, cmName string) *batchv1.Job {
 								},
 							},
 							VolumeMounts: getVolumeMounts(),
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:    "keystone-db-create",
-							Image:   "docker.io/tripleomaster/centos-binary-mariadb:current-tripleo",
-							Command: []string{"/bin/sh", "-c", util.ExecuteTemplateFile("db_create.sh", &opts)},
-							Env: []corev1.EnvVar{
-								{
-									Name:  "MYSQL_PWD",
-									Value: cr.Spec.DatabaseAdminPassword,
-								},
-							},
 						},
 					},
 				},

--- a/pkg/keystone/schema.go
+++ b/pkg/keystone/schema.go
@@ -1,0 +1,27 @@
+package keystone
+
+import (
+	comv1 "github.com/openstack-k8s-operators/keystone-operator/pkg/apis/keystone/v1"
+	util "github.com/openstack-k8s-operators/lib-common/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"strings"
+)
+
+type schemaOptions struct {
+	DatabaseHostname string
+	SchemaName       string
+	SchemaPassword   string
+}
+
+// SchemaObject func
+func SchemaObject(cr *comv1.KeystoneAPI) (unstructured.Unstructured, error) {
+	opts := schemaOptions{cr.Spec.DatabaseHostname, cr.Name, cr.Spec.DatabasePassword}
+
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(util.ExecuteTemplateFile("mariadb_schema.yaml", &opts)), 4096)
+	u := unstructured.Unstructured{}
+	err := decoder.Decode(&u)
+	u.SetNamespace(cr.Namespace)
+	return u, err
+}

--- a/templates/db_create.sh
+++ b/templates/db_create.sh
@@ -1,1 +1,0 @@
-mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "CREATE DATABASE IF NOT EXISTS keystone; GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' IDENTIFIED BY '{{.DatabasePassword}}';GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%' IDENTIFIED BY '{{.DatabasePassword}}';"

--- a/templates/mariadb_schema.yaml
+++ b/templates/mariadb_schema.yaml
@@ -1,0 +1,9 @@
+apiVersion: database.openstack.org/v1beta1
+kind: MariaDBSchema
+metadata:
+  name: {{.SchemaName}}
+  labels:
+    dbName: {{.DatabaseHostname}}
+spec:
+  name: {{.SchemaName}}
+  password: {{.SchemaPassword}}


### PR DESCRIPTION
This updates the keystone controller so that it rely's
on the mariadb-operator's MariaDBSchema to create
databases for us.

Important to note that the implementation uses the
unstructured k8s client so that we don't explicitly
depend on the mariadb-operator code struct's (and associated
golang lib versions).

The old code is removed from the dbsync job and we can
also remove the associated parameters.