### PR TITLE
Reworked Dockerfile.rhel for new pattern

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,62 @@
+# golang-builder is used in OSBS build
+ARG GOLANG_BUILDER=openshift/golang-builder:1.13
+ARG OPERATR_BASE_IMAGE=ubi8-minimal:8.1-released
+
+FROM ${GOLANG_BUILDER} AS builder
+
+# Intended to build in OSBS using cachito external sources bundle
+ARG REMOTE_SOURCE=.
+ARG REMOTE_SOURCE_DIR
+ARG REMOTE_SOURCE_SUBDIR=app
+ARG DEST_ROOT=/dest-root
+
+COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
+WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
+RUN mkdir -p $DEST_ROOT/usr/local/bin
+
+RUN go build -mod readonly -v -a -ldflags '-extldflags "-static"' -o $DEST_ROOT/usr/local/bin/manager main.go
+RUN go build -mod readonly -v -a -ldflags '-extldflags "-static"' -o $DEST_ROOT/usr/local/bin/csv-generator tools/csv-generator.go
+
+RUN cp tools/user_setup $DEST_ROOT/usr/local/bin
+RUN cp -r templates $DEST_ROOT/templates
+RUN mkdir -p $DEST_ROOT/config/crd/bases
+RUN cp config/crd/bases/* $DEST_ROOT/config/crd/bases
+
+FROM ${OPERATR_BASE_IMAGE}
+ARG DEST_ROOT=/dest-root
+
+LABEL   com.redhat.component="keystone-operator-container" \
+        name="keystone-operator" \
+        version="1.0" \
+        summary="Keystone Operator" \
+        io.k8s.name="keystone-operator" \
+        io.k8s.description="This image includes the keystone-operator"
+
+ENV USER_UID=1001 \
+    OPERATOR_TEMPLATES=/usr/share/keystone-operator/templates/ \
+    OPERATOR_BUNDLE=/usr/share/keystone-operator/bundle/
+
+# install operator binary
+COPY --from=builder $DEST_ROOT/usr/local/bin/* /usr/local/bin
+
+# install our templates
+RUN  mkdir -p ${OPERATOR_TEMPLATES}
+COPY --from=builder $DEST_ROOT/templates ${OPERATOR_TEMPLATES}
+
+# install CRDs and required roles, services, etc
+RUN  mkdir -p ${OPERATOR_BUNDLE}
+
+COPY --from=builder $DEST_ROOT/config/crd/bases/keystone.openstack.org_keystoneapis.yaml ${OPERATOR_BUNDLE}/keystone.openstack.org_keystoneapis_crd.yaml
+COPY --from=builder $DEST_ROOT/config/crd/bases/keystone.openstack.org_keystoneendpoints.yaml ${OPERATOR_BUNDLE}/keystone.openstack.org_keystoneendpoints_crd.yaml
+COPY --from=builder $DEST_ROOT/config/crd/bases/keystone.openstack.org_keystoneservices.yaml ${OPERATOR_BUNDLE}/keystone.openstack.org_keystoneservices_crd.yaml
+
+# strip top 2 lines (this resolves parsing in opm which handles this badly)
+RUN sed -i -e 1,2d ${OPERATOR_BUNDLE}/*
+
+WORKDIR /
+
+# user setup
+RUN  /usr/local/bin/user_setup
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/manager"]


### PR DESCRIPTION
with reworked operator-sdk the Dockerfile pattern shifted.  Updated
Dockerfile.rhel for the new pattern to see if we can get closer to
a single templated version that can be used in either system with less
changes.