### PR TITLE
Secrets and use MariaDBSchema CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Operator creates a custom KeystoneAPI resource that can be used to create Ke
 instances within the cluster. Example CR to create an Keystone API in your cluster:
 
 ```yaml
-apiVersion: keystone.openstack.org/v1
+apiVersion: keystone.openstack.org/v1beta1
 kind: KeystoneAPI
 metadata:
   name: keystone
@@ -21,14 +21,7 @@ spec:
   adminPassword: foobar123
   containerImage: docker.io/tripleostein/centos-binary-keystone:current-tripleo
   replicas: 1
-  databasePassword: foobar123
-  databaseHostname: openstack-db-mariadb
-  # used for keystone-manage bootstrap endpoints
-  apiEndpoint: http://keystone-test.apps.test.dprince/
-  # used to create the DB schema
-  databaseAdminUsername: root
-  databaseAdminPassword: foobar123
-  mysqlContainerImage: docker.io/tripleomaster/centos-binary-mariadb:current-tripleo
+  secret: keystone-secret
 ```
 
 # Design
@@ -40,7 +33,3 @@ The current design takes care of the following:
 - Generates Fernet keys (TODO: rotate them, and bounce the APIs upon rotation)
 - Keystone bootstrap, and db sync are executed automatically on install and updates
 - ConfigMap is recreated on any changes KeystoneAPI object changes and the Deployment updated.
-
-# Requirements
-
-- A MariaDB database. TODO move the db-create logic to a mariadb operator for OpenStack services

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -22,20 +22,12 @@ import (
 
 // KeystoneAPISpec defines the desired state of KeystoneAPI
 type KeystoneAPISpec struct {
-	// Keystone Database Password String
-	DatabasePassword string `json:"databasePassword,omitempty"`
 	// Keystone Database Hostname String
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 	// Keystone Container Image URL
 	ContainerImage string `json:"containerImage,omitempty"`
-	// Mysql Container Image URL (used for database syncing)
-	MysqlContainerImage string `json:"mysqlContainerImage,omitempty"`
-	// Database Admin Username
-	DatabaseAdminUsername string `json:"databaseAdminUsername,omitempty"`
-	// Database Admin Password
-	DatabaseAdminPassword string `json:"databaseAdminPassword,omitempty"`
-	// Keystone API Admin Password
-	AdminPassword string `json:"adminPassword,omitempty"`
+	// Keystone Secret containing DatabasePassword, AdminPassword
+	Secret string `json:"secret,omitempty"`
 	// Replicas
 	Replicas int32 `json:"replicas"`
 }

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -36,26 +36,11 @@ spec:
         spec:
           description: KeystoneAPISpec defines the desired state of KeystoneAPI
           properties:
-            adminPassword:
-              description: Keystone API Admin Password
-              type: string
             containerImage:
-              description: Keystone Container Image URL
-              type: string
-            databaseAdminPassword:
-              description: Database Admin Password
-              type: string
-            databaseAdminUsername:
-              description: Database Admin Username
+              description: Keystone Secret containing DatabasePassword, AdminPassword
               type: string
             databaseHostname:
               description: Keystone Database Hostname String
-              type: string
-            databasePassword:
-              description: Keystone Database Password String
-              type: string
-            mysqlContainerImage:
-              description: Mysql Container Image URL (used for database syncing)
               type: string
             replicas:
               description: Replicas

--- a/config/samples/keystone_v1beta1_keystoneapi.yaml
+++ b/config/samples/keystone_v1beta1_keystoneapi.yaml
@@ -1,7 +1,10 @@
 apiVersion: keystone.openstack.org/v1beta1
 kind: KeystoneAPI
 metadata:
-  name: keystoneapi-sample
+  name: keystone
+  namespace: openstack
 spec:
-  # Add fields here
-  foo: bar
+  containerImage: docker.io/tripleotrain/centos-binary-keystone:current-tripleo
+  replicas: 1
+  databaseHostname: mariadb
+  secret: keystone-secret

--- a/config/samples/secret.yaml
+++ b/config/samples/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keystone-secret
+stringData:
+  AdminPassword: foobar123
+  DatabasePassword: foobar123

--- a/pkg/keystone/configmap.go
+++ b/pkg/keystone/configmap.go
@@ -9,14 +9,12 @@ import (
 )
 
 type keystoneConfigOptions struct {
-	DatabasePassword string
 	DatabaseHostname string
-	AdminPassword    string
 }
 
 // ConfigMap custom keystone config map
 func ConfigMap(cr *keystonev1beta1.KeystoneAPI, cmName string) *corev1.ConfigMap {
-	opts := keystoneConfigOptions{cr.Spec.DatabasePassword, cr.Spec.DatabaseHostname, cr.Spec.AdminPassword}
+	opts := keystoneConfigOptions{cr.Spec.DatabaseHostname}
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/keystone/schema.go
+++ b/pkg/keystone/schema.go
@@ -1,0 +1,27 @@
+package keystone
+
+import (
+	keystonev1beta1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	util "github.com/openstack-k8s-operators/lib-common/pkg/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"strings"
+)
+
+type schemaOptions struct {
+	DatabaseHostname string
+	SchemaName       string
+	Secret           string
+}
+
+// SchemaObject func
+func SchemaObject(cr *keystonev1beta1.KeystoneAPI) (unstructured.Unstructured, error) {
+	opts := schemaOptions{cr.Spec.DatabaseHostname, cr.Name, cr.Spec.Secret}
+
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(util.ExecuteTemplateFile("mariadb_schema.yaml", &opts)), 4096)
+	u := unstructured.Unstructured{}
+	err := decoder.Decode(&u)
+	u.SetNamespace(cr.Namespace)
+	return u, err
+}

--- a/pkg/keystone/volumes.go
+++ b/pkg/keystone/volumes.go
@@ -8,7 +8,12 @@ import (
 func getVolumes(name string) []corev1.Volume {
 
 	return []corev1.Volume{
-
+		{
+			Name: "emptydir",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
 		{
 			Name: "kolla-config",
 			VolumeSource: corev1.VolumeSource{
@@ -57,6 +62,22 @@ func getVolumes(name string) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: "db-kolla-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: name,
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "db-sync-config.json",
+							Path: "config.json",
+						},
+					},
+				},
+			},
+		},
 	}
 
 }
@@ -79,6 +100,44 @@ func getVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 			Name:      "fernet-keys",
 		},
+		{
+			MountPath: "/var/lib/emptydir",
+			ReadOnly:  false,
+			Name:      "emptydir",
+		},
 	}
 
+}
+
+// common Keystone API VolumeMounts (db-kolla-config mounts passwords directly as keystone-api.conf)
+func getDbVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			MountPath: "/var/lib/config-data",
+			ReadOnly:  true,
+			Name:      "config-data",
+		},
+		{
+			MountPath: "/var/lib/kolla/config_files",
+			ReadOnly:  true,
+			Name:      "db-kolla-config",
+		},
+		{
+			MountPath: "/var/lib/emptydir",
+			ReadOnly:  false,
+			Name:      "emptydir",
+		},
+	}
+
+}
+
+// common Keystone API VolumeMounts for init/secrets container
+func getInitVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			MountPath: "/var/lib/emptydir",
+			ReadOnly:  false,
+			Name:      "emptydir",
+		},
+	}
 }

--- a/templates/db-sync-config.json
+++ b/templates/db-sync-config.json
@@ -1,0 +1,11 @@
+{
+  "command": "/bin/true",
+  "config_files": [
+    {
+      "source": "/var/lib/emptydir/keystone-passwords.conf",
+      "dest": "/etc/keystone/keystone-api.conf",
+      "owner": "keystone",
+      "perm": "0600"
+    }
+  ]
+}

--- a/templates/db_create.sh
+++ b/templates/db_create.sh
@@ -1,1 +1,0 @@
-mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "CREATE DATABASE IF NOT EXISTS keystone; GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' IDENTIFIED BY '{{.DatabasePassword}}';GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%' IDENTIFIED BY '{{.DatabasePassword}}';"

--- a/templates/keystone.conf
+++ b/templates/keystone.conf
@@ -1,12 +1,10 @@
 [DEFAULT]
-admin_token={{.AdminPassword}}
 log_config_append=/etc/keystone/logging.conf
 
 [catalog]
 template_file=/etc/keystone/default_catalog.templates
 
 [database]
-connection=mysql+pymysql://keystone:{{.DatabasePassword}}@{{.DatabaseHostname}}/keystone
 max_retries=-1
 db_max_retries=-1
 

--- a/templates/mariadb_schema.yaml
+++ b/templates/mariadb_schema.yaml
@@ -1,0 +1,9 @@
+apiVersion: database.openstack.org/v1beta1
+kind: MariaDBSchema
+metadata:
+  name: {{.SchemaName}}
+  labels:
+    dbName: {{.DatabaseHostname}}
+spec:
+  name: {{.SchemaName}}
+  password: {{.Secret}}

--- a/templates/password_init.sh
+++ b/templates/password_init.sh
@@ -1,0 +1,19 @@
+set -e
+
+# This script generates the keystone-passwords.conf file and copies the result
+# to the ephemeral /var/lib/emptydir volume (mounted by your init container).
+# 
+# Secrets are obtained from ENV variables.
+export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
+export AdminPassword=${AdminPassword:?"Please specify a AdminPassword variable."}
+export DatabaseHost=${DatabaseHost:?"Please specify a DatabaseHost variable."}
+export DatabaseUser=${DatabaseUser:-"keystone"}
+export DatabaseSchema=${DatabaseSchema:-"keystone"}
+
+cat > /var/lib/emptydir/keystone-passwords.conf <<-EOF_CAT
+[DEFAULT]
+admin_token=$AdminPassword
+
+[database]
+connection=mysql+pymysql://$DatabaseUser:$DatabasePassword@$DatabaseHost/$DatabaseSchema
+EOF_CAT


### PR DESCRIPTION
Updates the keystone CRD to use secrets.

Additionally, this updates the keystone controller so that it rely's
on the mariadb-operator's MariaDBSchema to create databases for us.

Important to note that the implementation uses the unstructured k8s
client so that we don't explicitly depend on the mariadb-operator code
struct's (and associated golang lib versions).

The old code is removed from the dbsync job and we can also remove
the associated parameters.