### PR TITLE
Set uniqe instance sample name

### DIFF
--- a/config/samples/keystone_v1beta1_keystoneapi.yaml
+++ b/config/samples/keystone_v1beta1_keystoneapi.yaml
@@ -1,7 +1,7 @@
 apiVersion: keystone.openstack.org/v1beta1
 kind: KeystoneAPI
 metadata:
-  name: openstack
+  name: keystone
 spec:
   containerImage: quay.io/tripleotraincentos8/centos-binary-keystone:current-tripleo
   replicas: 1


### PR DESCRIPTION
The instance name is used to create the DB for the service,
lets use a uniqe name for the keystoneapi for the sample to
not mess with other services sample.