### PR TITLE
Use /v3 for keystone livenessProbe and readinessProbe Path

### DIFF
--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -70,9 +70,11 @@ func Deployment(
 		// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 		//
 		livenessProbe.HTTPGet = &corev1.HTTPGetAction{
+			Path: "/v3",
 			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(KeystonePublicPort)},
 		}
 		readinessProbe.HTTPGet = &corev1.HTTPGetAction{
+			Path: "/v3",
 			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(KeystonePublicPort)},
 		}
 	}


### PR DESCRIPTION
The root of the API for the keystone service returns a 300
which k8s interprets as a problem (but not an outage, it's just a
warning):
~~~
Warning  ProbeWarning  3m14s (x170288 over 5d21h)  kubelet  Liveness probe warning: {"versions": {"values": [{"id": "v3.13", "status": "stable", "updated": "2019-07-19T00:00:00Z", "links": [{"rel": "self", "href": "http://10.217.1.13:5000/v3/"}], "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}]}]}}
~~~

This changes the URL to just check the v3 status which returns
200:

~~~
curl -i http://keystone-public-openstack.apps-crc.testing/v3
HTTP/1.1 200 OK
date: Tue, 19 Jul 2022 05:52:26 GMT
server: Apache
content-length: 277
vary: X-Auth-Token
x-openstack-request-id: req-c18ab220-a475-42e0-88cd-71b0fcbf74e3
content-type: application/json
set-cookie: b5697f82cf3c19ece8be533395142512=7df0468fa34542c82e1360c52e750ce2; path=/; HttpOnly
cache-control: private

{"version": {"id": "v3.14", "status": "stable", "updated": "2020-04-07T00:00:00Z", "links": [{"rel": "self", "href": "http://keystone-public-openstack.apps-crc.testing/v3/"}], "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}]}}
~~~