### PR TITLE
Remove kustomize in target if already installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+	rm -f $(LOCALBIN)/kustomize || true
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: controller-gen


### PR DESCRIPTION
Subsequent runs which call kustomize target stop with "Remove
first" message as it is already installed:

```
$ make install
.../bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 3.8.7 /.../keystone-operator/bin
.../keystone-operator/bin/kustomize exists. Remove it first.
make: *** [Makefile:170: .../keystone-operator/bin/kustomize] Error 1
```

Lets remove it if it is already installed to make sure the version
the Makefile wants is installed.