### PR TITLE
Move external pkg to the api sub module

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220816094529-135dc67c2cdf
+	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220909175216-e774739df18a
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	sigs.k8s.io/controller-runtime v0.12.3
@@ -29,6 +30,7 @@ require (
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
+	github.com/gophercloud/gophercloud v0.25.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -244,6 +244,8 @@ github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gophercloud/gophercloud v0.25.0 h1:C3Oae7y0fUVQGSsBrb3zliAjdX+riCSEh4lNMejFNI4=
+github.com/gophercloud/gophercloud v0.25.0/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -363,6 +365,8 @@ github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDD
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220816094529-135dc67c2cdf h1:jI+WnLrxELk3uJA6jYtg2xJs1S2/jLoUgCIulWnRb5I=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220816094529-135dc67c2cdf/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
+github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220909175216-e774739df18a h1:2pz0sqaS4zcw/OzmOxQUhUrhv+m6b28L3Jzi03X7Qik=
+github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220909175216-e774739df18a/go.mod h1:4jgM4ytAgA6NfbROZz4fDo0Zu25HRNgc72vQLXS15E0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -505,6 +509,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -13,15 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package external
+package v1beta1
 
-import (
-	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
-)
-
-// KeystoneService -
-type KeystoneService struct {
-	service *keystonev1.KeystoneService
+// KeystoneServiceHelper -
+type KeystoneServiceHelper struct {
+	service *KeystoneService
 	timeout int
 	labels  map[string]string
 	id      string

--- a/controllers/keystoneservice_controller.go
+++ b/controllers/keystoneservice_controller.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-logr/logr"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
-	external "github.com/openstack-k8s-operators/keystone-operator/pkg/external"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
@@ -144,7 +143,7 @@ func (r *KeystoneServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	// Validate that keystoneAPI is up
 	//
-	keystoneAPI, err := external.GetKeystoneAPI(ctx, helper, instance.Namespace, map[string]string{})
+	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, helper, instance.Namespace, map[string]string{})
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -179,7 +178,7 @@ func (r *KeystoneServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	// get admin authentication OpenStack
 	//
-	os, ctrlResult, err := external.GetAdminServiceClient(
+	os, ctrlResult, err := keystonev1.GetAdminServiceClient(
 		ctx,
 		helper,
 		keystoneAPI,

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20220727152756-f13e087e4199
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220816094529-135dc67c2cdf
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220816094529-135dc67c2cdf
-	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220816094529-135dc67c2cdf
+	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220909175216-e774739df18a
 	github.com/openstack-k8s-operators/mariadb-operator v0.0.0-20220714144434-169460573426
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-202208160945
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220816094529-135dc67c2cdf/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220816094529-135dc67c2cdf h1:jtsWoGItI10pa3p5yt1QQcXD4MGMpk/jItQSdSia14k=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220816094529-135dc67c2cdf/go.mod h1:iwUoeUPuyW2IWpUx5+iWkxzYxg1AybngHi9Ao6WKrak=
-github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220816094529-135dc67c2cdf h1:MbUCAOUjxq/BZ4JGl10qofiA9tW+miSCzIbKpPeOG0o=
-github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220816094529-135dc67c2cdf/go.mod h1:xZqqpTLe4GTqbEqrHkQIhq1MoecObHSk8SSAtTG/vnA=
+github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220909175216-e774739df18a h1:2pz0sqaS4zcw/OzmOxQUhUrhv+m6b28L3Jzi03X7Qik=
+github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220909175216-e774739df18a/go.mod h1:4jgM4ytAgA6NfbROZz4fDo0Zu25HRNgc72vQLXS15E0=
 github.com/openstack-k8s-operators/mariadb-operator v0.0.0-20220714144434-169460573426 h1:Oj0UfuyejYtv6kpjXsgOCd9NRvsxWSjGeYCmp/4QJvw=
 github.com/openstack-k8s-operators/mariadb-operator v0.0.0-20220714144434-169460573426/go.mod h1:Xk3692QuqfMBYjuElKHTdQxzUP00zx0QH0cgrcg1qv8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
With moving the external pkg to the api sub module the dependency to github.com/openstack-k8s-operators/keystone-operator can be removed on other operators. They would then only depend on github.com/openstack-k8s-operators/keystone-operator/api and don't import anything used in github.com/openstack-k8s-operators/keystone-operator which is not required.