### PR TITLE
Clarify which containers are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # keystone-operator
 
 A Kubernetes Operator built using the [Operator Framework](https://github.com/operator-framework) for Go. The Operator provides a way to easily install and manage an OpenStack Keystone installation
-on Kubernetes. This Operator was developed using [RDO](https://www.rdoproject.org/) containers for openStack.
+on Kubernetes. This Operator was developed using [TripleO](https://opendev.org/openstack/tripleo-common/src/branch/master/container-images/tripleo_containers.yaml) containers for OpenStack.
 
 # Deployment
 


### PR DESCRIPTION
RDO project does not build containers, only RPMs, which are then used by TripleO to build the container images using "tcib" definitions:

https://opendev.org/openstack/tripleo-common/src/branch/master/container-images/tcib