### PR TITLE
Cleanup jobs after hash is persisted

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -280,8 +280,7 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	dbSyncjob := job.NewJob(
 		jobDef,
 		keystonev1.DbSyncHash,
-		instance.Spec.PreserveJobs,
-		5,
+		time.Duration(5)*time.Second,
 		dbSyncHash,
 	)
 	ctrlResult, err = dbSyncjob.DoJob(
@@ -311,6 +310,12 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 			return ctrl.Result{}, err
 		}
 		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[keystonev1.DbSyncHash]))
+	}
+	if !instance.Spec.PreserveJobs {
+		err = job.DeleteAllSucceededJobs(ctx, helper, []string{instance.Status.Hash[keystonev1.DbSyncHash]})
+		if err != nil {
+			return ctrlResult, err
+		}
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 
@@ -374,8 +379,7 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	bootstrapjob := job.NewJob(
 		jobDef,
 		keystonev1.BootstrapHash,
-		instance.Spec.PreserveJobs,
-		5,
+		time.Duration(5)*time.Second,
 		instance.Status.Hash[keystonev1.BootstrapHash],
 	)
 	ctrlResult, err = bootstrapjob.DoJob(
@@ -405,6 +409,12 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 			return ctrl.Result{}, err
 		}
 		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[keystonev1.BootstrapHash]))
+	}
+	if !instance.Spec.PreserveJobs {
+		err = job.DeleteAllSucceededJobs(ctx, helper, []string{instance.Status.Hash[keystonev1.BootstrapHash]})
+		if err != nil {
+			return ctrlResult, err
+		}
 	}
 	instance.Status.Conditions.MarkTrue(condition.BootstrapReadyCondition, condition.BootstrapReadyMessage)
 

--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,5 @@ replace github.com/openstack-k8s-operators/keystone-operator/api => ./api
 // Without this, the following error occurs:
 // ../go/pkg/mod/k8s.io/apimachinery@v0.24.3/pkg/util/managedfields/gvkparser.go:62:39: cannot use smdschema.Schema{…} (value of type "sigs.k8s.io/structured-merge-diff/v4/schema".Schema) as type *"sigs.k8s.io/structured-merge-diff/v4/schema".Schema in struct literal
 replace sigs.k8s.io/structured-merge-diff/v4 v4.2.2 => sigs.k8s.io/structured-merge-diff/v4 v4.2.1
+
+replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff h1:R3q2BmVaVdvI/0/QUBO5khg7xXidsHQyKUViaFhU2t4=
+github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -319,8 +321,6 @@ github.com/onsi/gomega v1.22.1 h1:pY8O4lBfsHKZHM/6nrxkhVPUznOlIu3quZcKP/M20KI=
 github.com/onsi/gomega v1.22.1/go.mod h1:x6n7VNe4hw0vkyYUM4mjIXx3JbLiPaBPNgB7PRQ1tuM=
 github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220923094431-9fca0c85a9dc h1:UTbfs3HabSI6LtE8vVClFg/H2Zq79x+zbhclQHWwpkY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220923094431-9fca0c85a9dc/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220923094431-9fca0c85a9dc h1:87lUVT3MLRI4Vg0nHpupwPKXtykGX3hZzPl5k6Kcyng=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220923094431-9fca0c85a9dc/go.mod h1:umGUqQO4JtgefAaIwZjP+TxfxsLMEEeK/6VNzk8ooaI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220923094431-9fca0c85a9dc h1:yX4Y0mtSocfBXwI+WjQAr/FxfRVMBfKVmQ11dFJNveE=


### PR DESCRIPTION
There was a lib-common issue where job.DoJob() deleted the Job right after it is succeeded. Then the controller tried to store the hash of the Job in Status. But if that failed (due to e.g. Conflict) then in the next Reconcile call lib-common would re-create and re-run the Job as the hash of the previous Job and the Job itself is lost.

The lib-common is fixed in a way that the automatic Job deletion is removed from DoJob() and that needs to be now done on the caller side via the new job.DeleteAllSuccededJobs() call.

This patch adapts to the new lib-common version by doing the Job cleanup right after the Status.Update() successfully persisted the Job's hash.

Depends-On: openstack-k8s-operators/lib-common#77