### PR TITLE
Add e2e job for keystone operator

### DIFF
--- a/.github/workflows/label-on-pr.yaml
+++ b/.github/workflows/label-on-pr.yaml
@@ -1,0 +1,15 @@
+name: Workflow on label addition
+
+on:
+  pull_request_target:
+    types: [labeled]  
+    branches:
+      - 'master'
+
+jobs:
+  e2e:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-workflow-e2e.yaml@master
+    with:
+      operator_name: keystone-operator
+    secrets: inherit

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -1,0 +1,44 @@
+name: Pull Request Workflow
+
+# Run workflow when a new pull request is opened against master branch.
+on:
+  pull_request_target:
+    branches:
+    - 'master'
+
+jobs:
+  check_user_permission:
+    runs-on: ubuntu-latest
+    name: A job to check user's permission level
+    outputs:
+      has-permission: ${{ steps.check.outputs.has-permission }}
+    steps:
+      # Check for write permission
+      - name: Check user permission
+        id: check
+        uses: scherermichael-oss/action-has-permission@master
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  
+      - name: Add comment to PR if user has insufficient permissions
+        if: "! steps.check.outputs.has-permission"
+        env:
+          URL: ${{ github.event.pull_request.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            $URL \
+            -H "Content-Type: application/json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            --data '{ "body": "Sorry! Your permissions are insufficient. Request collaborators to add `ok-to-test` label to test this PR" }'
+
+  e2e:
+    if: ${{needs.check_user_permission.outputs.has-permission}}
+    needs: [check_user_permission]
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-workflow-e2e.yaml@master
+    with:
+      operator_name: keystone-operator
+    secrets: inherit


### PR DESCRIPTION
In Pr[1], we added a reusable workflow that build, install and test operator. With this commit, we are adding e2e job for keystone-operator by consuming the reusable workflow.

Keeping security in mind, By default, we will only trigger CI job if someone is collaborator/have write access on repo otherwise they will need a `ok-to-test` label from reviewer to run e2e job.

[1] https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci/pull/53