### PR TITLE
Pin operator-lint to v0.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,5 +286,5 @@ gowork: ## Generate go.work file to support our multi module repository
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@latest
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...


### PR DESCRIPTION
Originally I pointed the Makefile to @latest but that make the version uncontrollable and potentially operator-lint can break the repo with a new release.

So lets pin the operator-lint version.