### PR TITLE
Remove admin token

### DIFF
--- a/templates/keystoneapi/bin/init.sh
+++ b/templates/keystoneapi/bin/init.sh
@@ -42,5 +42,4 @@ do
 done
 
 # set secrets
-crudini --set ${SVC_CFG_MERGED} DEFAULT admin_token ${PASSWORD}
 crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}

--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -1,5 +1,4 @@
 [DEFAULT]
-# admin_token=${PASSWORD}
 log_config_append=/etc/keystone/logging.conf
 
 [catalog]


### PR DESCRIPTION
The admin token was deprecated a long ago when the new bootstrap process was added. The current implementation in keystone resources creation does not rely on it. We should avoid putting the unnecessary credential in config file.