### PR TITLE
Remove crc specific parameters from kuttl tests

### DIFF
--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -235,3 +235,21 @@ spec:
   to:
     kind: Service
     name: keystone-public
+---
+# the actual addresses of the apiEndpoints are platform specific, so we can't rely on 
+# kuttl asserts to check them. This short script gathers the addresses and checks that
+# the three endpoints are defined and their addresses follow the default pattern
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      set -x
+      template='{{.status.apiEndpoint.admin}}{{":"}}{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'                                                        
+      regex="http:\/\/keystone-admin-openstack\.apps.*:http:\/\/keystone-internal-openstack\.apps.*:http:\/\/keystone-public-openstack\.apps.*"
+      apiEndpoints=$(oc get -n openstack KeystoneAPI  keystone -o go-template=$template) 
+      if [[ "$apiEndpoints" =~ $regex ]]; then
+        exit 0
+      else
+        exit 1
+      fi

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -43,10 +43,6 @@ spec:
       memory: 500Mi
   secret: osp-secret
 status:
-  apiEndpoint:
-    admin: http://keystone-admin-openstack.apps-crc.testing
-    internal: http://keystone-internal-openstack.apps-crc.testing
-    public: http://keystone-public-openstack.apps-crc.testing
   databaseHostname: openstack
   readyCount: 1
 ---
@@ -204,7 +200,6 @@ metadata:
     service: keystone
   namespace: openstack
 spec:
-  host: keystone-admin-openstack.apps-crc.testing
   port:
     targetPort: keystone-admin
   to:
@@ -220,7 +215,6 @@ metadata:
     service: keystone
   namespace: openstack
 spec:
-  host: keystone-internal-openstack.apps-crc.testing
   port:
     targetPort: keystone-internal
   to:
@@ -236,7 +230,6 @@ metadata:
     service: keystone
   namespace: openstack
 spec:
-  host: keystone-public-openstack.apps-crc.testing
   port:
     targetPort: keystone-public
   to:

--- a/tests/kuttl/tests/keystone_scale/04-assert.yaml
+++ b/tests/kuttl/tests/keystone_scale/04-assert.yaml
@@ -38,10 +38,6 @@ spec:
       memory: 500Mi
   secret: osp-secret
 status:
-  apiEndpoint:
-    admin: http://keystone-admin-openstack.apps-crc.testing
-    internal: http://keystone-internal-openstack.apps-crc.testing
-    public: http://keystone-public-openstack.apps-crc.testing
   databaseHostname: openstack
 ---
 apiVersion: apps/v1

--- a/tests/kuttl/tests/keystone_scale/05-errors.yaml
+++ b/tests/kuttl/tests/keystone_scale/05-errors.yaml
@@ -84,7 +84,6 @@ metadata:
     service: keystone
   namespace: openstack
 spec:
-  host: keystone-admin-openstack.apps-crc.testing
   port:
     targetPort: keystone-admin
   to:
@@ -100,7 +99,6 @@ metadata:
     service: keystone
   namespace: openstack
 spec:
-  host: keystone-internal-openstack.apps-crc.testing
   port:
     targetPort: keystone-internal
   to:
@@ -116,7 +114,6 @@ metadata:
     service: keystone
   namespace: openstack
 spec:
-  host: keystone-public-openstack.apps-crc.testing
   port:
     targetPort: keystone-public
   to:


### PR DESCRIPTION
Remove some fields from the asserts (host in routes and apiEndpoints in
CR spec) that had crc specific values since those make the tests fail if
run in a cluster other than crc. It should be easy to check with
a regex, but kuttl does not support it. If they're really important to
check, can introduce a TestAssert for them and check the value with some
script.
