### PR TITLE
Use inclusive language for branch naming

### DIFF
--- a/.github/workflows/build-keystone-operator.yaml
+++ b/.github/workflows/build-keystone-operator.yaml
@@ -49,8 +49,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -122,8 +122,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
@@ -159,8 +159,8 @@ jobs:
       id: branch-name
       uses: tj-actions/branch-names@v5
 
-    - name: Set latest tag for non master branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'master' }}"
+    - name: Set latest tag for non main branch
+      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -1,10 +1,10 @@
 name: Pull Request Workflow
 
-# Run workflow when a new pull request is opened against master branch.
+# Run workflow when a new pull request is opened against main branch.
 on:
   pull_request_target:
     branches:
-    - 'master'
+    - 'main'
 
 jobs:
   check_user_permission:
@@ -16,7 +16,7 @@ jobs:
       # Check for write permission
       - name: Check user permission
         id: check
-        uses: scherermichael-oss/action-has-permission@master
+        uses: scherermichael-oss/action-has-permission@main
         with:
           required-permission: write
         env:
@@ -38,7 +38,7 @@ jobs:
   e2e:
     if: ${{needs.check_user_permission.outputs.has-permission}}
     needs: [check_user_permission]
-    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-workflow-e2e.yaml@master
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-workflow-e2e.yaml@main
     with:
       operator_name: keystone-operator
     secrets: inherit


### PR DESCRIPTION
In line with Red Hat's commitment to using inclusive language in our products. This change adds the necessary modifications to switch the default branch to use "main".