### PR TITLE
Assign the service role to service users

### DIFF
--- a/controllers/keystoneservice_controller.go
+++ b/controllers/keystoneservice_controller.go
@@ -430,7 +430,7 @@ func (r *KeystoneServiceReconciler) reconcileUser(
 	os *openstack.OpenStack,
 ) (reconcile.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling User %s", instance.Spec.ServiceUser))
-	roleName := "admin"
+	roleNames := []string{"admin", "service"}
 
 	// get the password of the service user from the secret
 	password, ctrlResult, err := secret.GetDataFromSecret(
@@ -447,7 +447,7 @@ func (r *KeystoneServiceReconciler) reconcileUser(
 	}
 
 	//
-	//  create service project if it does not exist
+	// create service project if it does not exist
 	//
 	serviceProjectID, err := os.CreateProject(
 		r.Log,
@@ -455,16 +455,6 @@ func (r *KeystoneServiceReconciler) reconcileUser(
 			Name:        "service",
 			Description: "service",
 		})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	//
-	//  create role if it does not exist
-	//
-	_, err = os.CreateRole(
-		r.Log,
-		roleName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -483,16 +473,28 @@ func (r *KeystoneServiceReconciler) reconcileUser(
 		return ctrl.Result{}, err
 	}
 
-	//
-	// add user to admin role
-	//
-	err = os.AssignUserRole(
-		r.Log,
-		roleName,
-		userID,
-		serviceProjectID)
-	if err != nil {
-		return ctrl.Result{}, err
+	for _, roleName := range roleNames {
+		//
+		// create role if it does not exist
+		//
+		_, err = os.CreateRole(
+			r.Log,
+			roleName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		//
+		// add the role to the user
+		//
+		err = os.AssignUserRole(
+			r.Log,
+			roleName,
+			userID,
+			serviceProjectID)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	r.Log.Info("Reconciled User successfully")


### PR DESCRIPTION
... in addition to the admin role. The service role is required for the following features.

- Some components such as nova uses service user token to interact with a different component with avoiding token expiration. Currently this feature can be used by any roles but in the future this would be allowed for only users with the service role.

- Keystone allows only system readers, service users or token subject to verify a token when SRBAC is enforced in Keystone.