### PR TITLE
Adapt assert check to use with sh and not bash

### DIFF
--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -244,11 +244,11 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      set -x
       template='{{.status.apiEndpoint.admin}}{{":"}}{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
       regex="http:\/\/keystone-admin-openstack\.apps.*:http:\/\/keystone-internal-openstack\.apps.*:http:\/\/keystone-public-openstack\.apps.*"
-      apiEndpoints=$(oc get -n openstack KeystoneAPI  keystone -o go-template=$template)
-      if [[ "$apiEndpoints" =~ $regex ]]; then
+      apiEndpoints=$(oc get -n openstack KeystoneAPI  keystone -o go-template="$template")
+      matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
+      if [ -z "$matches" ]; then
         exit 0
       else
         exit 1


### PR DESCRIPTION
When using TestAsserts in kuttl tests, the scripts are passed to 'sh -c', which  may or may not be a bash shell. To avoid failures in cases where  the shell is actually not bash, this change removes any bash-specific features from the kuttl tests.