### PR TITLE
Fix pattern to exclude bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 *.dll
 *.so
 *.dylib
-bin
+/bin
+testbin/*
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
Current pattern can match subdirectories.

Also, add the testbin directory to make the file consistent with the other operators.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>