### PR TITLE
Generate keys for credentials

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -497,7 +497,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 	}
 
 	//
-	// Create secret holding fernet keys
+	// Create secret holding fernet keys (for token and credential)
 	//
 	// TODO key rotation
 	err = r.ensureFernetKeys(ctx, instance, helper, &configMapVars)
@@ -774,16 +774,18 @@ func (r *KeystoneAPIReconciler) ensureFernetKeys(
 	//
 	// check if secret already exist
 	//
-	secret, hash, err := oko_secret.GetSecret(ctx, helper, keystone.ServiceName, instance.Namespace)
+	secretName := keystone.ServiceName
+	secret, hash, err := oko_secret.GetSecret(ctx, helper, secretName, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return err
 	} else if k8s_errors.IsNotFound(err) {
 		fernetKeys := map[string]string{
-			"0": keystone.GenerateFernetKey(),
-			"1": keystone.GenerateFernetKey(),
+			"FernetKeys0":     keystone.GenerateFernetKey(),
+			"FernetKeys1":     keystone.GenerateFernetKey(),
+			"CredentialKeys0": keystone.GenerateFernetKey(),
+			"CredentialKeys1": keystone.GenerateFernetKey(),
 		}
 
-		secretName := keystone.ServiceName
 		tmpl := []util.Template{
 			{
 				Name:       secretName,

--- a/pkg/keystone/volumes.go
+++ b/pkg/keystone/volumes.go
@@ -58,6 +58,34 @@ func getVolumes(name string) []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: ServiceName,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "FernetKeys0",
+							Path: "0",
+						},
+						{
+							Key:  "FernetKeys1",
+							Path: "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "credential-keys",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: ServiceName,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "CredentialKeys0",
+							Path: "0",
+						},
+						{
+							Key:  "CredentialKeys1",
+							Path: "1",
+						},
+					},
 				},
 			},
 		},
@@ -103,6 +131,11 @@ func getVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/var/lib/fernet-keys",
 			ReadOnly:  true,
 			Name:      "fernet-keys",
+		},
+		{
+			MountPath: "/var/lib/credential-keys",
+			ReadOnly:  true,
+			Name:      "credential-keys",
 		},
 	}
 }

--- a/templates/keystoneapi/config/keystone-api-config.json
+++ b/templates/keystoneapi/config/keystone-api-config.json
@@ -26,6 +26,12 @@
             "perm": "0644"
         },
         {
+            "source": "/var/lib/credential-keys",
+            "dest": "/etc/keystone/",
+            "owner": "keystone:keystone",
+            "perm": "0700"
+        },
+        {
             "source": "/var/lib/fernet-keys",
             "dest": "/etc/keystone/",
             "owner": "keystone:keystone",


### PR DESCRIPTION
Keystone uses fernet mechanism for not only tokens but also credentials and requires key files to use these features.

This introduces an additional secret file to store credential keys.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>