### PR TITLE
Fix wrong error handling of EnsureSecrets

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -794,11 +794,10 @@ func (r *KeystoneAPIReconciler) ensureFernetKeys(
 			},
 		}
 		err := oko_secret.EnsureSecrets(ctx, helper, instance, tmpl, envVars)
-		if err != nil {
-			return nil
-		}
 
-		return fmt.Errorf("OpenStack secret %s not found", secretName)
+		if err != nil {
+			return err
+		}
 	}
 
 	// TODO: fernet key rotation


### PR DESCRIPTION
The EnsureSecrets function returns nil if the secret exists or is created and returns error if something goes wrong.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>