### PR TITLE
Fix esnureFernetKeys()

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -799,12 +799,12 @@ func (r *KeystoneAPIReconciler) ensureFernetKeys(
 		if err != nil {
 			return err
 		}
+	} else {
+		// add hash to envVars
+		(*envVars)[secret.Name] = env.SetValue(hash)
 	}
 
 	// TODO: fernet key rotation
-
-	// add hash to envVars
-	(*envVars)[secret.Name] = env.SetValue(hash)
 
 	return nil
 }


### PR DESCRIPTION
secret is returned as nil from GetSecret() if the secret is not found. However, we try to use secret.Name before returning. This results in nil pointer derefence error and kills the controller.

Closes: #188