### PR TITLE
Run pre-commit with make

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,31 @@
 repos:
-- repo: https://github.com/dnephin/pre-commit-golang
-  rev: v0.5.1
-  hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
-    - id: go-mod-tidy
-
-- repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
-  hooks:
-    - id: golangci-lint
-
 - repo: local
   hooks:
+    - id: golangci-lint
+      name: golangci-lint
+      language: golang
+      types: [go]
+      entry: make
+      args: ["golangci-lint"]
+      pass_filenames: false
+    - id: gofmt
+      name: gofmt
+      language: system
+      entry: make
+      args: ["fmt"]
+      pass_filenames: false
+    - id: govet
+      name: govet
+      language: system
+      entry: make
+      args: ["vet"]
+      pass_filenames: false
+    - id: gotidy
+      name: gotidy
+      language: system
+      entry: make
+      args: ["tidy"]
+      pass_filenames: false
     - id: make-manifests
       name: make-manifests
       language: system
@@ -60,4 +72,4 @@ repos:
   rev: 2.1.1
   hooks:
     - id: bashate
-      entry: bashate --error . --ignore=E006,E040,E043
+      entry: bashate --error . --ignore=E006,E040,E011,E020,E012

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,18 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./api/...
 
+.PHONY: tidy
+tidy: fmt
+	go mod tidy; \
+	pushd "$(LOCALBIN)/../api"; \
+	go mod tidy; \
+	popd;
+
+.PHONY: golangci-lint
+golangci-lint:
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	$(LOCALBIN)/golangci-lint run --fix
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out


### PR DESCRIPTION
Updating pre-commit hook with make. pre-commit-golang repo is no longer maintained[1]. Instead of using
unmaintained repo we can use make to run pre-commit.

[1] https://github.com/dnephin/pre-commit-golang/issues/98