### PR TITLE
Sync CRD manifests

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -105,9 +105,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. logging.conf or policy.json. But can also be used
-                  to add additional files. Those get added to the service config dir
-                  in /etc/<service> . TODO: -> implement'
+                  files like e.g. policy.json. But can also be used to add additional
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
                 type: object
               externalEndpoints:
                 description: ExternalEndpoints, expose a VIP using a pre-created IPAddressPool

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -106,8 +106,8 @@ spec:
                   type: string
                 description: 'ConfigOverwrite - interface to overwrite default config
                   files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>.
-                  TODO: -> implement'
+                  files. Those get added to the service config dir in /etc/<service>
+                  . TODO: -> implement'
                 type: object
               externalEndpoints:
                 description: ExternalEndpoints, expose a VIP using a pre-created IPAddressPool


### PR DESCRIPTION
It seems the stored CRD manifests are not in sync with the golang type definition and it makes the pre-commit job fail. This commit sync the manifests by running `make manifests` and stores the result in the repo.