### PR TITLE
Use constant to define restart policy

### DIFF
--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -78,7 +78,7 @@ func BootstrapJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: ServiceAccount,
 					Containers: []corev1.Container{
 						{

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -62,7 +62,7 @@ func DbSyncJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: ServiceAccount,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
... instead hard-coding the string in our own logic.