### PR TITLE
Add cronjob to purge expired trusts

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -248,6 +248,20 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone KeystoneDatabasePassword, AdminPassword
                 type: string
+              trustFlushArgs:
+                default: ""
+                description: TrustFlushArgs - Arguments added to keystone-manage trust_flush
+                  command
+                type: string
+              trustFlushSchedule:
+                default: 1 * * * *
+                description: TrustFlushSchedule - Schedule to purge expired or soft-deleted
+                  trusts from database
+                type: string
+              trustFlushSuspend:
+                default: false
+                description: TrustFlushSuspend - Suspend the cron job to purge trusts
+                type: boolean
             required:
             - containerImage
             - databaseInstance

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -89,6 +89,21 @@ type KeystoneAPISpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	// TrustFlushArgs - Arguments added to keystone-manage trust_flush command
+	TrustFlushArgs string `json:"trustFlushArgs"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="1 * * * *"
+	// TrustFlushSchedule - Schedule to purge expired or soft-deleted trusts from database
+	TrustFlushSchedule string `json:"trustFlushSchedule"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// TrustFlushSuspend - Suspend the cron job to purge trusts
+	TrustFlushSuspend bool `json:"trustFlushSuspend"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: KeystoneDatabasePassword, admin: AdminPassword}
 	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -248,6 +248,20 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone KeystoneDatabasePassword, AdminPassword
                 type: string
+              trustFlushArgs:
+                default: ""
+                description: TrustFlushArgs - Arguments added to keystone-manage trust_flush
+                  command
+                type: string
+              trustFlushSchedule:
+                default: 1 * * * *
+                description: TrustFlushSchedule - Schedule to purge expired or soft-deleted
+                  trusts from database
+                type: string
+              trustFlushSuspend:
+                default: false
+                description: TrustFlushSuspend - Suspend the cron job to purge trusts
+                type: boolean
             required:
             - containerImage
             - databaseInstance

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,18 @@ rules:
 - apiGroups:
   - batch
   resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
   - jobs
   verbs:
   - create

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	configmap "github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
+	cronjob "github.com/openstack-k8s-operators/lib-common/modules/common/cronjob"
 	deployment "github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	endpoint "github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	env "github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -90,6 +91,7 @@ type KeystoneAPIReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbdatabases,verbs=get;list;watch;create;update;patch;delete;
@@ -157,7 +159,8 @@ func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
-			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage))
+			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
+			condition.UnknownCondition(condition.CronJobReadyCondition, condition.InitReason, condition.CronJobReadyInitMessage))
 
 		instance.Status.Conditions.Init(&cl)
 
@@ -189,6 +192,7 @@ func (r *KeystoneAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&keystonev1.KeystoneAPI{}).
 		Owns(&mariadbv1.MariaDBDatabase{}).
 		Owns(&batchv1.Job{}).
+		Owns(&batchv1.CronJob{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).
@@ -654,8 +658,28 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 	if instance.Status.ReadyCount > 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	}
-
 	// create Deployment - end
+
+	// create CronJob
+	cronjobDef := keystone.CronJob(instance, serviceLabels, serviceAnnotations)
+	cronjob := cronjob.NewCronJob(
+		cronjobDef,
+		time.Duration(5)*time.Second,
+	)
+
+	ctrlResult, err = cronjob.CreateOrPatch(ctx, helper)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.CronJobReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.CronJobReadyErrorMessage,
+			err.Error()))
+		return ctrlResult, err
+	}
+
+	instance.Status.Conditions.MarkTrue(condition.CronJobReadyCondition, condition.CronJobReadyMessage)
+	// create CronJob - end
 
 	//
 	// create OpenStackClient config

--- a/pkg/keystone/cronjob.go
+++ b/pkg/keystone/cronjob.go
@@ -1,0 +1,115 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	keystonev1beta1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	common "github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// TrustFlushCommand -
+	TrustFlushCommand = "/usr/local/bin/kolla_set_configs && keystone-manage trust_flush"
+)
+
+// CronJob func
+func CronJob(
+	instance *keystonev1beta1.KeystoneAPI,
+	labels map[string]string,
+	annotations map[string]string,
+) *batchv1.CronJob {
+	runAsUser := int64(0)
+
+	args := []string{"-c"}
+	if instance.Spec.Debug.Service {
+		args = append(args, common.DebugCommand)
+	} else {
+		args = append(args, TrustFlushCommand+instance.Spec.TrustFlushArgs)
+	}
+
+	envVars := map[string]env.Setter{}
+	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
+	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
+
+	parallelism := int32(1)
+	completions := int32(1)
+
+	cronjob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName + "-cron",
+			Namespace: instance.Namespace,
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          instance.Spec.TrustFlushSchedule,
+			Suspend:           &instance.Spec.TrustFlushSuspend,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: batchv1.JobSpec{
+					Parallelism: &parallelism,
+					Completions: &completions,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  ServiceName + "-cron",
+									Image: instance.Spec.ContainerImage,
+									Command: []string{
+										"/bin/bash",
+									},
+									Args:         args,
+									Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
+									VolumeMounts: getVolumeMounts(),
+									SecurityContext: &corev1.SecurityContext{
+										RunAsUser: &runAsUser,
+									},
+								},
+							},
+							Volumes:            getVolumes(instance.Name),
+							RestartPolicy:      corev1.RestartPolicyNever,
+							ServiceAccountName: ServiceAccount,
+						},
+					},
+				},
+			},
+		},
+	}
+	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
+		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	}
+
+	initContainerDetails := APIDetails{
+		ContainerImage:       instance.Spec.ContainerImage,
+		DatabaseHost:         instance.Status.DatabaseHostname,
+		DatabaseUser:         instance.Spec.DatabaseUser,
+		DatabaseName:         DatabaseName,
+		OSPSecret:            instance.Spec.Secret,
+		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
+		UserPasswordSelector: instance.Spec.PasswordSelectors.Admin,
+		VolumeMounts:         getInitVolumeMounts(),
+	}
+	cronjob.Spec.JobTemplate.Spec.Template.Spec.InitContainers = initContainer(initContainerDetails)
+
+	return cronjob
+}

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -106,6 +106,7 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ServiceAccount,
+					Volumes:            getVolumes(instance.Name),
 					Containers: []corev1.Container{
 						{
 							Name: ServiceName + "-api",
@@ -128,7 +129,6 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = getVolumes(instance.Name)
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible
 	// the get still created on the same worker node.


### PR DESCRIPTION
This change introduces the CronJob resource to periodically purge expired trusts from database.