### PR TITLE
Do not run redundant github actions running via prow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,6 +1,6 @@
 name: Golang lint, vet and unit test pipeline
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:


### PR DESCRIPTION
The github actions govet, lint, gotest, golangci ... run now on PRs via prow, which is redundant. Lets only run them on push, as its still useful to run them when pushing to the fork.