### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/mkeystoneapi.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export KEYSTONE_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+run-with-webhook: export KEYSTONE_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-keystone:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # keystone-operator
 
 A Kubernetes Operator built using the [Operator Framework](https://github.com/operator-framework) for Go. The Operator provides a way to easily install and manage an OpenStack Keystone installation
-on Kubernetes. This Operator was developed using [TripleO](https://opendev.org/openstack/tripleo-common/src/branch/master/container-images/tripleo_containers.yaml) containers for OpenStack.
+on Kubernetes. This Operator was developed using [TCIB](https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/containers.yaml) containers for OpenStack.
 
 # Deployment
 
@@ -18,7 +18,7 @@ kind: KeystoneAPI
 metadata:
   name: keystone
 spec:
-  containerImage: quay.io/tripleowallabycentos9/openstack-keystone:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   replicas: 1
   secret: keystone-secret
 ```

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: KEYSTONE_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-keystone:current-podified

--- a/config/samples/keystone_v1beta1_keystoneapi.yaml
+++ b/config/samples/keystone_v1beta1_keystoneapi.yaml
@@ -6,7 +6,7 @@ spec:
   adminProject: admin
   adminRole: admin
   adminUser: admin
-  containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -18,7 +18,7 @@ spec:
   adminProject: admin
   adminRole: admin
   adminUser: admin
-  containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true
@@ -73,7 +73,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -123,7 +123,7 @@ spec:
           value: keystone
         - name: DatabaseUser
           value: keystone
-        image: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}

--- a/tests/kuttl/tests/keystone_scale/05-assert.yaml
+++ b/tests/kuttl/tests/keystone_scale/05-assert.yaml
@@ -16,7 +16,7 @@ spec:
   adminProject: admin
   adminRole: admin
   adminUser: admin
-  containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib