### PR TITLE
Fix omitempty + default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,5 +316,5 @@ gowork: ## Generate go.work file to support our multi module repository
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...

--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -65,7 +65,6 @@ spec:
                 description: Keystone Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -92,7 +92,7 @@ type KeystoneAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: KeystoneDatabasePassword, admin: AdminPassword}
 	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
@@ -106,10 +106,9 @@ type KeystoneAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
-	PreserveJobs bool `json:"preserveJobs,omitempty"`
+	PreserveJobs bool `json:"preserveJobs"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
@@ -170,11 +169,11 @@ type PasswordSelector struct {
 	// +kubebuilder:default="KeystoneDatabasePassword"
 	// Database - Selector to get the keystone Database user password from the Secret
 	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database,omitempty"`
+	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="AdminPassword"
 	// Admin - Selector to get the keystone Admin password from the Secret
-	Admin string `json:"admin,omitempty"`
+	Admin string `json:"admin"`
 }
 
 // KeystoneDebug defines the observed state of KeystoneAPI
@@ -182,15 +181,15 @@ type KeystoneDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// DBSync enable debug
-	DBSync bool `json:"dbSync,omitempty"`
+	DBSync bool `json:"dbSync"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// ReadyCount enable debug
-	Bootstrap bool `json:"bootstrap,omitempty"`
+	Bootstrap bool `json:"bootstrap"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// Service enable debug
-	Service bool `json:"service,omitempty"`
+	Service bool `json:"service"`
 }
 
 // KeystoneAPIStatus defines the observed state of KeystoneAPI

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -65,7 +65,6 @@ spec:
                 description: Keystone Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets


### PR DESCRIPTION
Having a CRD field with omitempty tag with a kubebuilder default value defined can cause unexpected behavior. See
https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 for details.

So this patch remove the problematic definitions and bumps the operator-lint version to 0.3.0 that has a check to cover this.