### PR TITLE
Increase the timeout of golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ tidy: fmt
 .PHONY: golangci-lint
 golangci-lint:
 	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
-	$(LOCALBIN)/golangci-lint run --fix
+	$(LOCALBIN)/golangci-lint run --fix --verbose
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.


### PR DESCRIPTION
We see pre-commit job timeouts in CI due to golangci-lint running longer than the default 1 minute. So this PR bumping the timeout to 5 mins and enables verbose logging to see what take much time there.