### PR TITLE
Switch to  structured logging

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	keystone "github.com/openstack-k8s-operators/keystone-operator/pkg/keystone"
@@ -47,12 +46,14 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // GetClient -
@@ -65,21 +66,20 @@ func (r *KeystoneAPIReconciler) GetKClient() kubernetes.Interface {
 	return r.Kclient
 }
 
-// GetLogger -
-func (r *KeystoneAPIReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
 // GetScheme -
 func (r *KeystoneAPIReconciler) GetScheme() *runtime.Scheme {
 	return r.Scheme
+}
+
+// GetLog returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+func GetLog(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("KeystoneAPI")
 }
 
 // KeystoneAPIReconciler reconciles a KeystoneAPI object
 type KeystoneAPIReconciler struct {
 	client.Client
 	Kclient kubernetes.Interface
-	Log     logr.Logger
 	Scheme  *runtime.Scheme
 }
 
@@ -99,8 +99,6 @@ type KeystoneAPIReconciler struct {
 
 // Reconcile reconcile keystone API requests
 func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	_ = r.Log.WithValues("keystoneapi", req.NamespacedName)
-
 	// Fetch the KeystoneAPI instance
 	instance := &keystonev1.KeystoneAPI{}
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
@@ -120,7 +118,7 @@ func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		GetLog(ctx),
 	)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -202,8 +200,8 @@ func (r *KeystoneAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *KeystoneAPIReconciler) reconcileDelete(ctx context.Context, instance *keystonev1.KeystoneAPI, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service delete")
-
+	l := GetLog(ctx)
+	l.Info("Reconciling Service delete")
 	// remove db finalizer before the keystone one
 	db, err := database.GetDatabaseByName(ctx, helper, instance.Name)
 	if err != nil && !k8s_errors.IsNotFound(err) {
@@ -218,7 +216,7 @@ func (r *KeystoneAPIReconciler) reconcileDelete(ctx context.Context, instance *k
 
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
-	r.Log.Info("Reconciled Service delete successfully")
+	l.Info("Reconciled Service delete successfully")
 
 	return ctrl.Result{}, nil
 }
@@ -230,8 +228,8 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	serviceLabels map[string]string,
 	serviceAnnotations map[string]string,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service init")
-
+	l := GetLog(ctx)
+	l.Info("Reconciling Service init")
 	//
 	// create service DB instance
 	//
@@ -326,7 +324,7 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	}
 	if dbSyncjob.HasChanged() {
 		instance.Status.Hash[keystonev1.DbSyncHash] = dbSyncjob.GetHash()
-		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[keystonev1.DbSyncHash]))
+		l.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[keystonev1.DbSyncHash]))
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 
@@ -427,38 +425,41 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	}
 	if bootstrapjob.HasChanged() {
 		instance.Status.Hash[keystonev1.BootstrapHash] = bootstrapjob.GetHash()
-		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[keystonev1.BootstrapHash]))
+		l.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[keystonev1.BootstrapHash]))
 	}
 	instance.Status.Conditions.MarkTrue(condition.BootstrapReadyCondition, condition.BootstrapReadyMessage)
 
 	// run keystone bootstrap - end
 
-	r.Log.Info("Reconciled Service init successfully")
+	l.Info("Reconciled Service init successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *KeystoneAPIReconciler) reconcileUpdate(ctx context.Context, instance *keystonev1.KeystoneAPI, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service update")
+	l := GetLog(ctx)
+	l.Info("Reconciling Service update")
 
 	// TODO: should have minor update tasks if required
 	// - delete dbsync hash from status to rerun it?
 
-	r.Log.Info("Reconciled Service update successfully")
+	l.Info("Reconciled Service update successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *KeystoneAPIReconciler) reconcileUpgrade(ctx context.Context, instance *keystonev1.KeystoneAPI, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service upgrade")
+	l := GetLog(ctx)
+	l.Info("Reconciling Service upgrade")
 
 	// TODO: should have major version upgrade tasks
 	// -delete dbsync hash from status to rerun it?
 
-	r.Log.Info("Reconciled Service upgrade successfully")
+	l.Info("Reconciled Service upgrade successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *keystonev1.KeystoneAPI, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service")
+	l := GetLog(ctx)
+	l.Info("Reconciling Service")
 
 	// ConfigMap
 	configMapVars := make(map[string]env.Setter)
@@ -689,7 +690,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 		return ctrl.Result{}, err
 	}
 
-	r.Log.Info("Reconciled Service successfully")
+	l.Info("Reconciled Service successfully")
 	return ctrl.Result{}, nil
 }
 
@@ -898,7 +899,7 @@ func (r *KeystoneAPIReconciler) createHashOfInputHashes(
 	}
 	if hashMap, changed = util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
-		r.Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
+		GetLog(ctx).Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, changed, nil
 }

--- a/controllers/keystoneendpoint_controller.go
+++ b/controllers/keystoneendpoint_controller.go
@@ -26,9 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/go-logr/logr"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -41,7 +39,6 @@ import (
 type KeystoneEndpointReconciler struct {
 	client.Client
 	Kclient kubernetes.Interface
-	Log     logr.Logger
 	Scheme  *runtime.Scheme
 }
 
@@ -54,7 +51,7 @@ type KeystoneEndpointReconciler struct {
 
 // Reconcile keystone endpoint requests
 func (r *KeystoneEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	_ = log.FromContext(ctx)
+	l := GetLog(ctx)
 
 	// Fetch the KeystoneEndpoint instance
 	instance := &keystonev1.KeystoneEndpoint{}
@@ -75,7 +72,8 @@ func (r *KeystoneEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		//TODO remove later, log used here as to not break the helper struct signiture.
+		l,
 	)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -138,7 +136,7 @@ func (r *KeystoneEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				condition.SeverityWarning,
 				keystonev1.KeystoneAPIReadyNotFoundMessage,
 			))
-			util.LogForObject(helper, "KeystoneAPI not found!", instance)
+			l.Info("KeystoneAPI not found!")
 
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
@@ -179,7 +177,7 @@ func (r *KeystoneEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			keystonev1.KeystoneAPIReadyWaitingMessage))
-		util.LogForObject(helper, "KeystoneAPI not yet ready!", instance)
+		l.Info("KeystoneAPI not yet ready!")
 
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
@@ -235,7 +233,9 @@ func (r *KeystoneEndpointReconciler) reconcileDelete(
 	os *openstack.OpenStack,
 	keystoneAPI *keystonev1.KeystoneAPI,
 ) (ctrl.Result, error) {
-	util.LogForObject(helper, "Reconciling Endpoint delete", instance)
+	l := GetLog(ctx)
+
+	l.Info("Reconciling Endpoint delete")
 
 	// We might not have an OpenStack backend to use in certain situations
 	if os != nil {
@@ -249,7 +249,7 @@ func (r *KeystoneEndpointReconciler) reconcileDelete(
 			}
 
 			err = os.DeleteEndpoint(
-				r.Log,
+				l,
 				openstack.Endpoint{
 					Name:         instance.Spec.ServiceName,
 					ServiceID:    instance.Status.ServiceID,
@@ -276,7 +276,7 @@ func (r *KeystoneEndpointReconciler) reconcileDelete(
 
 	// Endpoints are deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
-	util.LogForObject(helper, "Reconciled Endpoint delete successfully", instance)
+	l.Info("Reconciled Endpoint delete successfully")
 
 	return ctrl.Result{}, nil
 }
@@ -287,7 +287,8 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 	helper *helper.Helper,
 	os *openstack.OpenStack,
 ) (ctrl.Result, error) {
-	util.LogForObject(helper, "Reconciling Endpoint normal", instance)
+	l := GetLog(ctx)
+	l.Info("Reconciling Endpoint normal")
 
 	//
 	// Wait for KeystoneService is Ready and get the ServiceID from the object
@@ -295,7 +296,7 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 	ksSvc, err := keystonev1.GetKeystoneServiceWithName(ctx, helper, instance.Spec.ServiceName, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			util.LogForObject(helper, fmt.Sprintf("KeystoneService %s not found", instance.Spec.ServiceName), instance)
+			l.Info("KeystoneService not found", "KeystoneService", instance.Spec.ServiceName)
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
 
@@ -309,7 +310,7 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 	}
 
 	if !ksSvc.IsReady() {
-		util.LogForObject(helper, fmt.Sprintf("KeystoneService %s not ready, waiting to create endpoints", instance.Spec.ServiceName), instance)
+		l.Info("KeystoneService not ready, waiting to create endpoints", "KeystoneService", instance.Spec.ServiceName)
 
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
@@ -320,6 +321,7 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 	// create/update endpoints
 	//
 	err = r.reconcileEndpoints(
+		ctx,
 		instance,
 		helper,
 		os)
@@ -338,17 +340,19 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 		instance.Spec.Endpoints,
 	)
 
-	util.LogForObject(helper, "Reconciled Endpoint normal successfully", instance)
+	l.Info("Reconciled Endpoint normal successfully")
 
 	return ctrl.Result{}, nil
 }
 
 func (r *KeystoneEndpointReconciler) reconcileEndpoints(
+	ctx context.Context,
 	instance *keystonev1.KeystoneEndpoint,
 	helper *helper.Helper,
 	os *openstack.OpenStack,
 ) error {
-	util.LogForObject(helper, "Reconciling Endpoints", instance)
+	l := GetLog(ctx)
+	l.Info("Reconciling Endpoints")
 
 	// delete endpoint if it does no longer exist in Spec.Endpoints
 	// but has a reference in Status.EndpointIDs
@@ -362,7 +366,7 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 				}
 
 				err = os.DeleteEndpoint(
-					r.Log,
+					l,
 					openstack.Endpoint{
 						Name:         instance.Spec.ServiceName,
 						ServiceID:    instance.Status.ServiceID,
@@ -390,7 +394,7 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 
 		// get registered endpoints for the service and endpointType
 		allEndpoints, err := os.GetEndpoints(
-			r.Log,
+			l,
 			instance.Status.ServiceID,
 			endpointType)
 		if err != nil {
@@ -401,7 +405,7 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 		if len(allEndpoints) == 0 {
 			// Create the endpoint
 			endpointID, err = os.CreateEndpoint(
-				r.Log,
+				l,
 				openstack.Endpoint{
 					Name:         instance.Spec.ServiceName,
 					ServiceID:    instance.Status.ServiceID,
@@ -417,7 +421,7 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 			endpoint := allEndpoints[0]
 			if endpointURL != endpoint.URL {
 				endpointID, err = os.UpdateEndpoint(
-					r.Log,
+					l,
 					openstack.Endpoint{
 						Name:         endpoint.Name,
 						ServiceID:    endpoint.ServiceID,
@@ -447,7 +451,7 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 		}
 	}
 
-	util.LogForObject(helper, "Reconciled Endpoints successfully", instance)
+	l.Info("Reconciled Endpoints successfully")
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -102,7 +102,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("KeystoneAPI"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeystoneAPI")
 		os.Exit(1)
@@ -112,7 +111,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("KeystoneService"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeystoneService")
 		os.Exit(1)
@@ -122,7 +120,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("KeystoneEndpoint"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeystoneEndpoint")
 		os.Exit(1)


### PR DESCRIPTION
Switch to  structured logging


This automatically adds additional fields like reconcile_id etc.. from the controller context.

before : 
```bash
2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully
```

after:
```bash
2023-05-18T02:00:28+03:00       INFO    Controllers.KeystoneAPI Reconciled Service init successfully    {"controller": "keystoneapi", "controllerGroup": "keystone.openstack.org", "controllerKind":"KeystoneAPI", "KeystoneAPI": {"name":"keystone","namespace":"openstack"}, "namespace": "openstack", "name": "keystone", "reconcileID": "512a4d9b-f31d-4fa4-a4cc-cd6c13e4455d"}
```