### PR TITLE
Change renovate to use make tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["make gowork", "go mod tidy", "make manifests generate"],
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
     "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }


### PR DESCRIPTION
Now that make tidy updates both mod files in the repo renovates should
use that target to generate the PRs.