### PR TITLE
Make string equality POSIX sh compatible

### DIFF
--- a/tests/kuttl/common/scripts/check_debug_in_keystone_pod_logs.sh
+++ b/tests/kuttl/common/scripts/check_debug_in_keystone_pod_logs.sh
@@ -2,7 +2,7 @@
 #
 found=0
 not_found=1
-if [ "$1" == "--reverse" ];then
+if [ "$1" = "--reverse" ];then
     # sometimes we want to check that there is no DEBUG logs
     found=1
     not_found=0


### PR DESCRIPTION
If /bin/sh does not point to bash then
check_debug_in_keystone_pod_logs.sh fails with

check_debug_in_keystone_pod_logs.sh: 5: [: --reverse: unexpected operator

Shellcheck points out the error:

$ shellcheck tests/kuttl/common/scripts/check_debug_in_keystone_pod_logs.sh

In tests/kuttl/common/scripts/check_debug_in_keystone_pod_logs.sh line 5: if [ "$1" == "--reverse" ];then
          ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

For more information:
  https://www.shellcheck.net/wiki/SC3014 -- In POSIX sh, == in place of = is ...

So this patch fixes the equality operator