### PR TITLE
Add native interface to customize policy

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -64,6 +64,12 @@ spec:
                 description: Keystone Container Image URL (will be set to environmental
                   default if empty)
                 type: string
+              customPolicies:
+                description: CustomPolicies - customize the policy rules using this
+                  parameter to change service defaults, or overwrite rendered information
+                  using raw yaml format. The content gets added to to /etc/<service>/policy.d
+                  directory as custom.yaml file.
+                type: string
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
@@ -103,10 +109,9 @@ spec:
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  . TODO: -> implement'
+                description: ConfigOverwrite - interface to overwrite default config
+                  files. But can also be used to add additional files. Those get added
+                  to the service config dir in /etc/<service> .
                 type: object
               externalEndpoints:
                 description: ExternalEndpoints, expose a VIP using a pre-created IPAddressPool

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -114,9 +114,14 @@ type KeystoneAPISpec struct {
 	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
+	// CustomPolicies - customize the policy rules using this parameter to change service defaults,
+	// or overwrite rendered information using raw yaml format. The content gets added to
+	// to /etc/<service>/policy.d directory as custom.yaml file.
+	CustomPolicies string `json:"customPolicies,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// ConfigOverwrite - interface to overwrite default config files.
 	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	// TODO: -> implement
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -64,6 +64,12 @@ spec:
                 description: Keystone Container Image URL (will be set to environmental
                   default if empty)
                 type: string
+              customPolicies:
+                description: CustomPolicies - customize the policy rules using this
+                  parameter to change service defaults, or overwrite rendered information
+                  using raw yaml format. The content gets added to to /etc/<service>/policy.d
+                  directory as custom.yaml file.
+                type: string
               customServiceConfig:
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
@@ -103,10 +109,9 @@ spec:
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  . TODO: -> implement'
+                description: ConfigOverwrite - interface to overwrite default config
+                  files. But can also be used to add additional files. Those get added
+                  to the service config dir in /etc/<service> .
                 type: object
               externalEndpoints:
                 description: ExternalEndpoints, expose a VIP using a pre-created IPAddressPool

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -690,7 +690,11 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	// custom.conf is going to /etc/<service>/<service>.conf.d
 	// all other files get placed into /etc/<service> to allow overwrite of e.g. policy.json
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{
+		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		// TODO: Replace this string by CustomPolicyFileName
+		"custom.yaml": instance.Spec.CustomPolicies,
+	}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}

--- a/templates/keystoneapi/config/keystone-api-config.json
+++ b/templates/keystoneapi/config/keystone-api-config.json
@@ -14,6 +14,12 @@
             "perm": "0600"
         },
         {
+            "source": "/var/lib/config-data/merged/custom.yaml",
+            "dest": "/etc/keystone/policy.d/custom.yaml",
+            "owner": "keystone",
+            "perm": "0600"
+        },
+        {
             "source": "/var/lib/config-data/merged/httpd.conf",
             "dest": "/etc/httpd/conf/httpd.conf",
             "owner": "root",


### PR DESCRIPTION
This introduces the new native interface so that users can inject customized policy rules. This interface depends on the capability of oslo.policy which loads separate files from policy.d directory. This is much flexible than using the base policy.yaml file because it allows us to use the default policy rules installed by rpm (eg. octavia) and override only specific rules.