### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/keystone/const.go
+++ b/pkg/keystone/const.go
@@ -21,8 +21,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "keystone"
 
-	// KeystoneAdminPort -
-	KeystoneAdminPort int32 = 35357
 	// KeystonePublicPort -
 	KeystonePublicPort int32 = 5000
 	// KeystoneInternalPort -


### PR DESCRIPTION
The constant has not been used since we stop creating admin endpoint.