### PR TITLE
Drop unused binding of tcp/35357

### DIFF
--- a/templates/keystoneapi/config/httpd.conf
+++ b/templates/keystoneapi/config/httpd.conf
@@ -8,7 +8,6 @@ ServerName "localhost.localdomain"
 User apache
 Group apache
 
-Listen 35357
 Listen 5000
 
 TypesConfig /etc/mime.types
@@ -23,7 +22,7 @@ SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
-<VirtualHost *:5000 *:35357>
+<VirtualHost *:5000>
   DocumentRoot "/var/www/cgi-bin/keystone"
 
   <Directory "/var/www/cgi-bin/keystone">


### PR DESCRIPTION
Since we removed admin endpoint, we no longer use the separate tcp for admin endpoint.