### PR TITLE
Directly use wsgi script installed by rpm

### DIFF
--- a/templates/keystoneapi/config/httpd.conf
+++ b/templates/keystoneapi/config/httpd.conf
@@ -40,6 +40,6 @@ CustomLog /dev/stdout proxy env=forwarded
   WSGIApplicationGroup %{GLOBAL}
   WSGIDaemonProcess keystone display-name=keystone group=keystone processes=3 threads=1 user=keystone
   WSGIProcessGroup keystone
-  WSGIScriptAlias / "/var/www/cgi-bin/keystone/main"
+  WSGIScriptAlias / "/usr/bin/keystone-wsgi-public"
   WSGIPassAuthorization On
 </VirtualHost>


### PR DESCRIPTION
... instead of the path copied during container image build. This allows us to reduce steps in image build.