### PR TITLE
Rename apiEndpoint key for consistency

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -274,6 +274,11 @@ spec:
               apiEndpoint:
                 additionalProperties:
                   type: string
+                description: API endpoint (deprecated)
+                type: object
+              apiEndpoints:
+                additionalProperties:
+                  type: string
                 description: API endpoint
                 type: object
               conditions:

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -221,7 +221,10 @@ type KeystoneAPIStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 
 	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
+	APIEndpoints map[string]string `json:"apiEndpoints,omitempty"`
+
+	// API endpoint (deprecated)
+	APIEndpoint map[string]string `json:"apiEndpoint,omitempty"`
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -161,6 +161,13 @@ func (in *KeystoneAPIStatus) DeepCopyInto(out *KeystoneAPIStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.APIEndpoint != nil {
+		in, out := &in.APIEndpoint, &out.APIEndpoint
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -274,6 +274,11 @@ spec:
               apiEndpoint:
                 additionalProperties:
                   type: string
+                description: API endpoint (deprecated)
+                type: object
+              apiEndpoints:
+                additionalProperties:
+                  type: string
                 description: API endpoint
                 type: object
               conditions:

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -184,6 +184,9 @@ func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
+	if instance.Status.APIEndpoint == nil {
+		instance.Status.APIEndpoint = map[string]string{}
+	}
 	if instance.Status.APIEndpoints == nil {
 		instance.Status.APIEndpoints = map[string]string{}
 	}
@@ -423,10 +426,8 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	// Update instance status with service endpoint url from route host information
 	//
 	// TODO: need to support https default here
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
 	instance.Status.APIEndpoints = apiEndpoints
+	instance.Status.APIEndpoint = apiEndpoints
 
 	// expose service - end
 

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -190,7 +190,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      template='{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
+      template='{{.status.apiEndpoints.internal}}{{":"}}{{.status.apiEndpoints.public}}{{"\n"}}'
       regex="http:\/\/keystone-internal.$NAMESPACE.*:http:\/\/keystone-public-$NAMESPACE\.apps.*"
       apiEndpoints=$(oc get -n $NAMESPACE KeystoneAPI  keystone -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")


### PR DESCRIPTION
The apiEndpoint field in status presents multiple endpoints(internal and public). This renames the key to the plural, to make the key name consistent with what is presented in that field.
