### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -269,10 +269,9 @@ func (instance KeystoneAPI) GetEndpoint(endpointType endpoint.Endpoint) (string,
 	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if KeystoneAPI is reconciled successfully
 func (instance KeystoneAPI) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.ExposeServiceReadyCondition) &&
-		instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // RbacConditionsSet - set the conditions for the rbac object

--- a/api/v1beta1/keystoneendpoint_types.go
+++ b/api/v1beta1/keystoneendpoint_types.go
@@ -66,7 +66,7 @@ func init() {
 	SchemeBuilder.Register(&KeystoneEndpoint{}, &KeystoneEndpointList{})
 }
 
-// IsReady - returns true if endpoint got created ok in keystone
+// IsReady - returns true if KeystoneEndpoint is reconciled successfully
 func (instance KeystoneEndpoint) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(KeystoneServiceOSEndpointsReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/api/v1beta1/keystoneservice_types.go
+++ b/api/v1beta1/keystoneservice_types.go
@@ -80,11 +80,7 @@ func init() {
 	SchemeBuilder.Register(&KeystoneService{}, &KeystoneServiceList{})
 }
 
-// IsReady - returns true if service, endpoints and user got created ok in keystone
-// AND the service ID registerd in the object status
+// IsReady - returns true if KeystoneService is reconciled successfully
 func (instance KeystoneService) IsReady() bool {
-
-	return instance.Status.Conditions.IsTrue(KeystoneServiceOSServiceReadyCondition) &&
-		instance.Status.Conditions.IsTrue(KeystoneServiceOSUserReadyCondition) &&
-		instance.Status.ServiceID != ""
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -137,11 +137,18 @@ func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/keystoneendpoint_controller.go
+++ b/controllers/keystoneendpoint_controller.go
@@ -83,11 +83,18 @@ func (r *KeystoneEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/keystoneservice_controller.go
+++ b/controllers/keystoneservice_controller.go
@@ -103,11 +103,18 @@ func (r *KeystoneServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.