### PR TITLE
Prohibit changing name of admin role

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -52,10 +52,6 @@ spec:
                 default: admin
                 description: AdminProject - admin project name
                 type: string
-              adminRole:
-                default: admin
-                description: AdminRole - admin role name
-                type: string
               adminUser:
                 default: admin
                 description: AdminUser - admin user name

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -71,11 +71,6 @@ type KeystoneAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=admin
-	// AdminRole - admin role name
-	AdminRole string `json:"adminRole"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=admin
 	// AdminUser - admin user name
 	AdminUser string `json:"adminUser"`
 

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -52,10 +52,6 @@ spec:
                 default: admin
                 description: AdminProject - admin project name
                 type: string
-              adminRole:
-                default: admin
-                description: AdminRole - admin role name
-                type: string
               adminUser:
                 default: admin
                 description: AdminUser - admin user name

--- a/config/samples/keystone_v1beta1_keystoneapi.yaml
+++ b/config/samples/keystone_v1beta1_keystoneapi.yaml
@@ -4,7 +4,6 @@ metadata:
   name: keystone
 spec:
   adminProject: admin
-  adminRole: admin
   adminUser: admin
   containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   customServiceConfig: |

--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -52,7 +52,6 @@ func BootstrapJob(
 	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("true")
 	envVars["OS_BOOTSTRAP_USERNAME"] = env.SetValue(instance.Spec.AdminUser)
 	envVars["OS_BOOTSTRAP_PROJECT_NAME"] = env.SetValue(instance.Spec.AdminProject)
-	envVars["OS_BOOTSTRAP_ROLE_NAME"] = env.SetValue(instance.Spec.AdminRole)
 	envVars["OS_BOOTSTRAP_SERVICE_NAME"] = env.SetValue(ServiceName)
 	envVars["OS_BOOTSTRAP_REGION_ID"] = env.SetValue(instance.Spec.Region)
 

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -15,7 +15,6 @@ metadata:
   name: keystone
 spec:
   adminProject: admin
-  adminRole: admin
   adminUser: admin
   containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   customServiceConfig: |

--- a/tests/kuttl/tests/keystone_scale/05-assert.yaml
+++ b/tests/kuttl/tests/keystone_scale/05-assert.yaml
@@ -13,7 +13,6 @@ metadata:
   name: keystone
 spec:
   adminProject: admin
-  adminRole: admin
   adminUser: admin
   containerImage: quay.io/podified-antelope-centos9/openstack-keystone:current-podified
   customServiceConfig: |


### PR DESCRIPTION
The policy rules implemented in each service expect the admin role is named "admin", and the policy enforcement results in unexpected denials if we use a different role name.