### PR TITLE
Name resources according to instance.Name

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -594,7 +594,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector: keystone.ServiceName,
+		common.AppSelector: instance.Name,
 	}
 
 	// networks to attach to
@@ -822,6 +822,8 @@ func (r *KeystoneAPIReconciler) reconcileCloudConfig(
 		"OS_CLOUD":    "default",
 	}
 
+	// NOTE: We still use static name for this because the name is used by
+	//       infra-operator
 	cms := []util.Template{
 		{
 			Name:          "openstack-config",
@@ -863,6 +865,8 @@ func (r *KeystoneAPIReconciler) reconcileCloudConfig(
 		"secure.yaml": string(secretVal),
 	}
 
+	// NOTE: We still use static name for this because the name is used by
+	//       infra-operator
 	secrets := []util.Template{
 		{
 			Name:          "openstack-config-secret",
@@ -890,7 +894,7 @@ func (r *KeystoneAPIReconciler) ensureFernetKeys(
 	//
 	// check if secret already exist
 	//
-	secretName := keystone.ServiceName
+	secretName := instance.Name
 	secret, hash, err := oko_secret.GetSecret(ctx, helper, secretName, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return err

--- a/pkg/keystone/cronjob.go
+++ b/pkg/keystone/cronjob.go
@@ -54,7 +54,7 @@ func CronJob(
 
 	cronjob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName + "-cron",
+			Name:      instance.Name + "-cron",
 			Namespace: instance.Namespace,
 		},
 		Spec: batchv1.CronJobSpec{

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -52,7 +52,7 @@ func DbSyncJob(
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName + "-db-sync",
+			Name:      instance.Name + "-db-sync",
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -84,7 +84,7 @@ func DbSyncJob(
 		},
 	}
 
-	job.Spec.Template.Spec.Volumes = getVolumes(ServiceName)
+	job.Spec.Template.Spec.Volumes = getVolumes(instance.Name)
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -91,7 +91,7 @@ func Deployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -135,7 +135,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			ServiceName,
+			labels[common.AppSelector],
 		},
 		corev1.LabelHostname,
 	)

--- a/pkg/keystone/volumes.go
+++ b/pkg/keystone/volumes.go
@@ -57,7 +57,7 @@ func getVolumes(name string) []corev1.Volume {
 			Name: "fernet-keys",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: ServiceName,
+					SecretName: name,
 					Items: []corev1.KeyToPath{
 						{
 							Key:  "FernetKeys0",
@@ -75,7 +75,7 @@ func getVolumes(name string) []corev1.Volume {
 			Name: "credential-keys",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: ServiceName,
+					SecretName: name,
 					Items: []corev1.KeyToPath{
 						{
 							Key:  "CredentialKeys0",


### PR DESCRIPTION
... instead of using static names. This allows us to make naming more consistent across operators. Although we don't support deploying multiple control planes in a single name space, we have to deploy multiple instances of some CR(eg GlanceAPI) in the single namespace to deploy a single control plane, so instance.Name is the preferred method to name resources. This does not care about the naming conflicts between CRs in case different CRs are deployed with the same name, because adding prefix causes redundant names. (for example if a user deploys a KeystoneAPI instance with name keystone, we prefer creating a deployment with name keystone instead of keystone-keystone).

Note that this change does not change name of client config because that requires update in OpenStackClient controller.