### PR TITLE
Allow configuring timezone

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -245,6 +245,10 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone KeystoneDatabasePassword, AdminPassword
                 type: string
+              timeZone:
+                default: UTC
+                description: TimeZone - Timezone in pods
+                type: string
               trustFlushArgs:
                 default: ""
                 description: TrustFlushArgs - Arguments added to keystone-manage trust_flush
@@ -263,6 +267,7 @@ spec:
             - containerImage
             - databaseInstance
             - secret
+            - timeZone
             type: object
           status:
             description: KeystoneAPIStatus defines the observed state of KeystoneAPI

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -147,6 +147,11 @@ type KeystoneAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// ExternalEndpoints, expose a VIP using a pre-created IPAddressPool
 	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
+
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=UTC
+	// TimeZone - Timezone in pods
+	TimeZone string `json:"timeZone"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -245,6 +245,10 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone KeystoneDatabasePassword, AdminPassword
                 type: string
+              timeZone:
+                default: UTC
+                description: TimeZone - Timezone in pods
+                type: string
               trustFlushArgs:
                 default: ""
                 description: TrustFlushArgs - Arguments added to keystone-manage trust_flush
@@ -263,6 +267,7 @@ spec:
             - containerImage
             - databaseInstance
             - secret
+            - timeZone
             type: object
           status:
             description: KeystoneAPIStatus defines the observed state of KeystoneAPI

--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -64,6 +64,7 @@ func BootstrapJob(
 	if _, ok := endpoints["public"]; ok {
 		envVars["OS_BOOTSTRAP_PUBLIC_URL"] = env.SetValue(endpoints["public"])
 	}
+	envVars["TZ"] = env.SetValue(instance.Spec.TimeZone)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/keystone/cronjob.go
+++ b/pkg/keystone/cronjob.go
@@ -48,6 +48,7 @@ func CronJob(
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
+	envVars["TZ"] = env.SetValue(instance.Spec.TimeZone)
 
 	parallelism := int32(1)
 	completions := int32(1)
@@ -58,6 +59,7 @@ func CronJob(
 			Namespace: instance.Namespace,
 		},
 		Spec: batchv1.CronJobSpec{
+			TimeZone:          &instance.Spec.TimeZone,
 			Schedule:          instance.Spec.TrustFlushSchedule,
 			Suspend:           &instance.Spec.TrustFlushSuspend,
 			ConcurrencyPolicy: batchv1.ForbidConcurrent,

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -49,6 +49,7 @@ func DbSyncJob(
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("true")
+	envVars["TZ"] = env.SetValue(instance.Spec.TimeZone)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -88,6 +88,7 @@ func Deployment(
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
+	envVars["TZ"] = env.SetValue(instance.Spec.TimeZone)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -152,6 +153,7 @@ func Deployment(
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Admin,
 		VolumeMounts:         getInitVolumeMounts(),
+		TimeZone:             instance.Spec.TimeZone,
 	}
 	deployment.Spec.Template.Spec.InitContainers = initContainer(initContainerDetails)
 

--- a/pkg/keystone/initcontainer.go
+++ b/pkg/keystone/initcontainer.go
@@ -31,6 +31,7 @@ type APIDetails struct {
 	DBPasswordSelector   string
 	UserPasswordSelector string
 	VolumeMounts         []corev1.VolumeMount
+	TimeZone             string
 }
 
 const (
@@ -51,6 +52,7 @@ func initContainer(init APIDetails) []corev1.Container {
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
 	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
+	envVars["TZ"] = env.SetValue(init.TimeZone)
 
 	envs := []corev1.EnvVar{
 		{


### PR DESCRIPTION
This introduces the TimeZone spec to allow users to customize timezone used by pods, so that logs are recorded with local time.