### PR TITLE
Ensure KeystoneAPI is ready in kuttl tests

### DIFF
--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -40,6 +40,9 @@ spec:
 status:
   databaseHostname: openstack
   readyCount: 1
+  conditions:
+  - status: "True"
+    type: Ready
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/kuttl/tests/keystone_scale/03-assert.yaml
+++ b/tests/kuttl/tests/keystone_scale/03-assert.yaml
@@ -16,6 +16,9 @@ spec:
   replicas: 3
 status:
   readyCount: 3
+  conditions:
+  - status: "True"
+    type: Ready
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/kuttl/tests/keystone_scale/04-assert.yaml
+++ b/tests/kuttl/tests/keystone_scale/04-assert.yaml
@@ -15,6 +15,9 @@ spec:
   replicas: 1
 status:
   readyCount: 1
+  conditions:
+  - status: "True"
+    type: Ready
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/kuttl/tests/keystone_scale/05-assert.yaml
+++ b/tests/kuttl/tests/keystone_scale/05-assert.yaml
@@ -37,6 +37,9 @@ spec:
   secret: keystone-secret
 status:
   databaseHostname: openstack
+  conditions:
+  - status: "False"
+    type: Ready
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This ensures the Ready condition of KeystoneAPI becomes ready in every deployment step. Note that the condition should be false in case no pod is available so it is intentionally asserted to be false in case keystone service is scaled down to 0.