### PR TITLE
Remove redundant default of PasswordSelectors

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -159,9 +159,6 @@ spec:
                   this service
                 type: object
               passwordSelectors:
-                default:
-                  admin: AdminPassword
-                  database: KeystoneDatabasePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   AdminUser password from the Secret
                 properties:

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -105,7 +105,7 @@ type KeystoneAPISpec struct {
 	TrustFlushSuspend bool `json:"trustFlushSuspend"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: KeystoneDatabasePassword, admin: AdminPassword}
+	// +kubebuilder:default={}
 	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -159,9 +159,6 @@ spec:
                   this service
                 type: object
               passwordSelectors:
-                default:
-                  admin: AdminPassword
-                  database: KeystoneDatabasePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   AdminUser password from the Secret
                 properties:


### PR DESCRIPTION
Currently we define defaults in two layers but this is redundant.