### PR TITLE
Remove redundant [catalog] template_file

### DIFF
--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -6,9 +6,6 @@ backend=dogpile.cache.pymemcache
 enabled=true
 memcache_servers={{ .memcachedServers }}
 
-[catalog]
-template_file=/etc/keystone/default_catalog.templates
-
 [database]
 max_retries=-1
 db_max_retries=-1


### PR DESCRIPTION
Keystone by default tries to look up the template file at /etc/keystone/default_catalog.templates without any customization, thus the current definition is just redundant.

Also, we haven't really used template driver for catalong and sql driver is much more often used. The default catalog file contains quite old content and hasn't been updated for long until [1] was merged very recently.

[1] https://review.opendev.org/c/openstack/keystone/+/879142