### PR TITLE
Control deletion of service dependencies

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -204,7 +204,14 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
+- apiGroups:
+  - memcached.openstack.org
+  resources:
+  - memcacheds/finalizers
+  verbs:
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
We have been seeing an error in `OpenStackControlPlane` deletion where Keystone and MariaDB resources linger without being fully cleaned-up.  This is due to Keystone now using Memcached.  When the `OpenStackControlPlane` is deleted, what happens is that `Memcached` and its pod are deleted before the deletion logic in Keystone can complete.  This results in the reconcile loops of `KeystoneEndpoint` and `KeystoneService` hitting server errors when calling the admin client to remove their entries on the OpenStack side of things  (because the cache disappeared and the Keystone API can't find it, so it throws a 500 error).  Then, due to these errors, the OpenShift side does not ever finish cleaning up the associated resources.

This patch introduces two things:

1. `KeystoneAPI` now adds a finalizer to its `Memcached` dependency resource to prevent it from being deleted while the `KeystoneAPI` is still in service.
2. The `KeystoneAPI` does not remove its finalizer from `Memcached` _nor_ MariaDB/Galera _nor_ itself until the `KeystoneEndpoint` and `KeystoneService` CRs have themselves removed their finalizers from the `KeystoneAPI` CR.

I worry that this new logic will introduce hangs elsewhere, but I have not seen anything so far in my testing.  Those tests have by no means been exhaustive, however.  The purpose of this PR is, at the very least, to get a conversation going in regards to this issue even if we don't go with this solution.