### PR TITLE
envtest: Use latest bug fix version of k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 DEFAULT_IMG ?= quay.io/openstack-k8s-operators/keystone-operator:latest
 IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.1
+ENVTEST_K8S_VERSION = 1.26
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
This is follow-up of ee391d33f9b47ec6cf0e731d80f1f9cb6a0dee96 and updates the version string so that the latest bug fix version of 1.26 release is used instead of using the specific bug fix version.