### PR TITLE
Skip redundant update when removing a finalizer

### DIFF
--- a/api/v1beta1/keystoneendpoint.go
+++ b/api/v1beta1/keystoneendpoint.go
@@ -136,9 +136,11 @@ func (ke *KeystoneEndpointHelper) Delete(
 	}
 
 	// Endpoint is deleted so remove the finalizer.
-	controllerutil.RemoveFinalizer(endpoint, h.GetFinalizer())
-	if err := h.GetClient().Update(ctx, endpoint); err != nil && !k8s_errors.IsNotFound(err) {
-		return err
+	if controllerutil.RemoveFinalizer(endpoint, h.GetFinalizer()) {
+		err := h.GetClient().Update(ctx, endpoint)
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	h.GetLogger().Info(fmt.Sprintf("KeystoneEndpoint %s in namespace %s deleted", endpoint.Name, endpoint.Namespace))

--- a/api/v1beta1/keystoneservice.go
+++ b/api/v1beta1/keystoneservice.go
@@ -135,9 +135,11 @@ func (ks *KeystoneServiceHelper) Delete(
 	}
 
 	// Service is deleted so remove the finalizer.
-	controllerutil.RemoveFinalizer(service, h.GetFinalizer())
-	if err := h.GetClient().Update(ctx, service); err != nil && !k8s_errors.IsNotFound(err) {
-		return err
+	if controllerutil.RemoveFinalizer(service, h.GetFinalizer()) {
+		err := h.GetClient().Update(ctx, service)
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	h.GetLogger().Info(fmt.Sprintf("KeystoneService %s in namespace %s deleted", service.Name, service.Namespace))


### PR DESCRIPTION
We don't have to update a CR when the CR does not contain the finalizer being removed.