### PR TITLE
Do not multiply time.Second by time.Duration

### DIFF
--- a/api/v1beta1/keystoneapi.go
+++ b/api/v1beta1/keystoneapi.go
@@ -86,7 +86,7 @@ func GetAdminServiceClient(
 		ctx,
 		h,
 		keystoneAPI.Spec.Secret,
-		time.Duration(10)*time.Second,
+		10*time.Second,
 		keystoneAPI.Spec.PasswordSelectors.Admin)
 	if err != nil {
 		return nil, ctrl.Result{}, err

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -419,7 +419,7 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 		jobDef,
 		keystonev1.DbSyncHash,
 		instance.Spec.PreserveJobs,
-		time.Duration(5)*time.Second,
+		5*time.Second,
 		dbSyncHash,
 	)
 	ctrlResult, err = dbSyncjob.DoJob(
@@ -481,7 +481,7 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 		keystone.ServiceName,
 		serviceLabels,
 		keystonePorts,
-		time.Duration(5)*time.Second,
+		5*time.Second,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -517,7 +517,7 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 		jobDef,
 		keystonev1.BootstrapHash,
 		instance.Spec.PreserveJobs,
-		time.Duration(5)*time.Second,
+		5*time.Second,
 		instance.Status.Hash[keystonev1.BootstrapHash],
 	)
 	ctrlResult, err = bootstrapjob.DoJob(
@@ -620,7 +620,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.MemcachedReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("memcached %s not found", instance.Spec.MemcachedInstance)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("memcached %s not found", instance.Spec.MemcachedInstance)
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
@@ -652,7 +652,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.MemcachedReadyWaitingMessage))
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("memcached %s is not ready", memcached.Name)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("memcached %s is not ready", memcached.Name)
 	}
 	// Mark the Memcached Service as Ready if we get to this point with no errors
 	instance.Status.Conditions.MarkTrue(
@@ -781,7 +781,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 	deplDef := keystone.Deployment(instance, inputHash, serviceLabels, serviceAnnotations)
 	depl := deployment.NewDeployment(
 		deplDef,
-		time.Duration(5)*time.Second,
+		5*time.Second,
 	)
 
 	ctrlResult, err = depl.CreateOrPatch(ctx, helper)
@@ -839,7 +839,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(ctx context.Context, instance *k
 	cronjobDef := keystone.CronJob(instance, serviceLabels, serviceAnnotations)
 	cronjob := cronjob.NewCronJob(
 		cronjobDef,
-		time.Duration(5)*time.Second,
+		5*time.Second,
 	)
 
 	ctrlResult, err = cronjob.CreateOrPatch(ctx, helper)

--- a/controllers/keystoneendpoint_controller.go
+++ b/controllers/keystoneendpoint_controller.go
@@ -334,7 +334,7 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 	if !ksSvc.IsReady() {
 		l.Info("KeystoneService not ready, waiting to create endpoints", "KeystoneService", instance.Spec.ServiceName)
 
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	instance.Status.ServiceID = ksSvc.Status.ServiceID

--- a/controllers/keystoneservice_controller.go
+++ b/controllers/keystoneservice_controller.go
@@ -439,7 +439,7 @@ func (r *KeystoneServiceReconciler) reconcileUser(
 		ctx,
 		h,
 		instance.Spec.Secret,
-		time.Duration(10)*time.Second,
+		10*time.Second,
 		instance.Spec.PasswordSelector)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -154,7 +154,7 @@ var _ = BeforeSuite(func() {
 	}()
 
 	// wait for the webhook server to get ready
-	dialer := &net.Dialer{Timeout: time.Duration(10) * time.Second}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
 		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})


### PR DESCRIPTION
time.Second already represents duration. We don't have to use time.Duration to generate n seconds but can use a normal integer.