### PR TITLE
[envtest]Use database helpers from mariadb-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.9
 	k8s.io/apimachinery v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.2023092
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:+iJZo5alCeOGD/524hWWdlINA6zqY+MjfWT7cDcbvBE=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17 h1:zJguNin+9IwRnGKy1A7ranxASKO1vTvWxoXwkCz8MWw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17/go.mod h1:YOFHrNK/QqCvZUPlDJYmDyaCkbKIB98V04uyofiC9a8=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c h1:9R8T1WRwuPS5KMfsQWxAMSGPuJrGMJ7bODKK9dirhHA=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c/go.mod h1:xXHF/R/L0XamRHR/UkzlgzSTocBQ6GSQ2U16Q9Mf/bA=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4 h1:37bbJ9XzpCvB+zZckdweJEEH3pqM6Q88OHH8eHFvlpI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -234,8 +234,8 @@ var _ = Describe("Keystone controller", func() {
 				Namespace: namespace,
 			})
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetKeystoneAPI(keystoneApiName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -243,7 +243,7 @@ var _ = Describe("Keystone controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(keystoneApiName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneApiName)
 		})
 
 		It("should have db ready condition", func() {
@@ -285,8 +285,8 @@ var _ = Describe("Keystone controller", func() {
 				Namespace: namespace,
 			})
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetKeystoneAPI(keystoneApiName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -294,7 +294,7 @@ var _ = Describe("Keystone controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(keystoneApiName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneApiName)
 			th.SimulateJobSuccess(dbSyncJobName)
 		})
 
@@ -343,8 +343,8 @@ var _ = Describe("Keystone controller", func() {
 				Namespace: namespace,
 			})
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetKeystoneAPI(keystoneApiName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -352,7 +352,7 @@ var _ = Describe("Keystone controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(keystoneApiName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneApiName)
 			th.SimulateJobSuccess(dbSyncJobName)
 			th.SimulateJobSuccess(bootstrapJobName)
 		})
@@ -402,8 +402,8 @@ var _ = Describe("Keystone controller", func() {
 				Namespace: namespace,
 			})
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetKeystoneAPI(keystoneApiName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -411,7 +411,7 @@ var _ = Describe("Keystone controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(keystoneApiName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneApiName)
 			th.SimulateJobSuccess(dbSyncJobName)
 			th.SimulateJobSuccess(bootstrapJobName)
 			th.SimulateDeploymentReplicaReady(deploymentName)
@@ -499,8 +499,8 @@ var _ = Describe("Keystone controller", func() {
 				Namespace: namespace,
 			})
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetKeystoneAPI(keystoneApiName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -508,7 +508,7 @@ var _ = Describe("Keystone controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(keystoneApiName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneApiName)
 			th.SimulateJobSuccess(dbSyncJobName)
 			th.SimulateJobSuccess(bootstrapJobName)
 			th.SimulateDeploymentReplicaReady(deploymentName)
@@ -565,8 +565,8 @@ var _ = Describe("Keystone controller", func() {
 				Namespace: namespace,
 			})
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetKeystoneAPI(keystoneApiName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -574,7 +574,7 @@ var _ = Describe("Keystone controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(keystoneApiName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneApiName)
 			th.SimulateJobSuccess(dbSyncJobName)
 			th.SimulateJobSuccess(bootstrapJobName)
 			th.SimulateDeploymentReplicaReady(deploymentName)

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -32,6 +32,7 @@ import (
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	"github.com/openstack-k8s-operators/keystone-operator/controllers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -47,6 +48,7 @@ var (
 	logger    logr.Logger
 	th        *common_test.TestHelper
 	keystone  *keystone_test.TestHelper
+	mariadb   *mariadb_test.TestHelper
 	namespace string
 )
 
@@ -116,7 +118,9 @@ var _ = BeforeSuite(func() {
 	th = common_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 	keystone = keystone_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
-	Expect(th).NotTo(BeNil())
+	Expect(keystone).NotTo(BeNil())
+	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(mariadb).NotTo(BeNil())
 
 	// Start the controller-manager if goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common