### PR TITLE
[envtest]Use infra helpers from infra-operator

### DIFF
--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -166,8 +166,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateKeystoneAPI(keystoneApiName, GetDefaultKeystoneAPISpec()))
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -228,8 +228,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateKeystoneAPI(keystoneApiName, GetDefaultKeystoneAPISpec()))
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -279,8 +279,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateKeystoneAPI(keystoneApiName, GetDefaultKeystoneAPISpec()))
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -337,8 +337,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateKeystoneAPI(keystoneApiName, GetDefaultKeystoneAPISpec()))
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -396,8 +396,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateKeystoneAPI(keystoneApiName, GetDefaultKeystoneAPISpec()))
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -493,8 +493,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, keystone)
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -559,8 +559,8 @@ var _ = Describe("Keystone controller", func() {
 			DeferCleanup(th.DeleteInstance, keystone)
 			DeferCleanup(
 				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
-			DeferCleanup(th.DeleteMemcached, th.CreateMemcached(namespace, "memcached", memcachedSpec))
-			th.SimulateMemcachedReady(types.NamespacedName{
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -29,6 +29,7 @@ import (
 	test "github.com/openstack-k8s-operators/lib-common/modules/test"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
+	infra_test "github.com/openstack-k8s-operators/infra-operator/apis/test/helpers"
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	"github.com/openstack-k8s-operators/keystone-operator/controllers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
@@ -49,6 +50,7 @@ var (
 	th        *common_test.TestHelper
 	keystone  *keystone_test.TestHelper
 	mariadb   *mariadb_test.TestHelper
+	infra     *infra_test.TestHelper
 	namespace string
 )
 
@@ -121,6 +123,8 @@ var _ = BeforeSuite(func() {
 	Expect(keystone).NotTo(BeNil())
 	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(mariadb).NotTo(BeNil())
+	infra = infra_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(infra).NotTo(BeNil())
 
 	// Start the controller-manager if goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common