### PR TITLE
Enable Secure RBAC by default

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -86,6 +86,11 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
+              enableSecureRBAC:
+                default: true
+                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                  policies
+                type: boolean
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -97,6 +97,11 @@ type KeystoneAPISpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
+	// EnableSecureRBAC - Enable Consistent and Secure RBAC policies
+	EnableSecureRBAC bool `json:"enableSecureRBAC"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=""
 	// TrustFlushArgs - Arguments added to keystone-manage trust_flush command
 	TrustFlushArgs string `json:"trustFlushArgs"`

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -86,6 +86,11 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
+              enableSecureRBAC:
+                default: true
+                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                  policies
+                type: boolean
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -1198,6 +1198,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 			instance.Status.DatabaseHostname,
 			keystone.DatabaseName,
 		),
+		"enableSecureRBAC": instance.Spec.EnableSecureRBAC,
 	}
 
 	// create httpd  vhost template parameters

--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -11,6 +11,10 @@ max_retries=-1
 db_max_retries=-1
 connection={{ .DatabaseConnection }}
 
+[oslo_policy]
+enforce_new_defaults = {{ .enableSecureRBAC }}
+enforce_scope = {{ .enableSecureRBAC }}
+
 [fernet_tokens]
 key_repository=/etc/keystone/fernet-keys
 max_active_keys=2


### PR DESCRIPTION
This patch adds a new field to the Keystone API spec to configure "Consistent and Secure RBAC" [1].  It is enabled by default.

Jira: [OSPRH-2128](https://issues.redhat.com//browse/OSPRH-2128)

[1] https://governance.openstack.org/tc/goals/selected/consistent-and-secure-rbac.html