### PR TITLE
Update to golang 1.21

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.19-sdk-1.31
+  tag: ci-build-root-golang-1.21-sdk-1.31

--- a/.github/workflows/build-keystone-operator.yaml
+++ b/.github/workflows/build-keystone-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: keystone
-      go_version: 1.19.x
+      go_version: 1.21.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}


### PR DESCRIPTION
This patch updates Prow and Github action CI jobs to use golang 1.21 which was recently added by [1]

[1] https://github.com/openshift/release/pull/46906

Jira: [OSPRH-2705](https://issues.redhat.com//browse/OSPRH-2705)
Jira: [OSPRH-2668](https://issues.redhat.com//browse/OSPRH-2668)