### PR TITLE
Use common RabbitMqTransportURLReadyCondition

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -35,9 +35,6 @@ const (
 
 	// KeystoneServiceOSUserReadyCondition Status=True condition which indicates if the service user got created in the keystone instance is ready/was successful
 	KeystoneServiceOSUserReadyCondition condition.Type = "KeystoneServiceOSUserReady"
-
-	// KeystoneRabbitMQTransportURLReadyCondition -
-	KeystoneRabbitMQTransportURLReadyCondition condition.Type = "KeystoneRabbitMQTransportURLReady"
 )
 
 // Common Messages used by API objects.
@@ -114,12 +111,4 @@ const (
 
 	// KeystoneServiceOSUserReadyErrorMessage
 	KeystoneServiceOSUserReadyErrorMessage = "Keystone Service user error occured %s"
-
-	// RabbitMQTransportURLReadyRunningMessage -
-	KeystoneRabbitMQTransportURLReadyRunningMessage = "KeystoneRabbitMQTransportURL creation in progress"
-	// RabbitMQTransportURLReadyMessage -
-	KeystoneRabbitMQTransportURLReadyMessage = "KeystoneRabbitMQTransportURL successfully created"
-	// RabbitMQTransportURLReadyErrorMessage -
-	KeystoneRabbitMQTransportURLReadyErrorMessage = "KeystoneRabbitMQTransportURL error occured %s"
-
 )

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -182,6 +182,7 @@ func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		cl := condition.CreateList(
 			condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
 			condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
+			condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 			condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
 			condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
 			condition.UnknownCondition(condition.BootstrapReadyCondition, condition.InitReason, condition.BootstrapReadyInitMessage),
@@ -796,10 +797,10 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			keystonev1.KeystoneRabbitMQTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			keystonev1.KeystoneRabbitMQTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -812,14 +813,14 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	if instance.Status.TransportURLSecret == "" {
 		l.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			keystonev1.KeystoneRabbitMQTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
-			keystonev1.KeystoneRabbitMQTransportURLReadyRunningMessage))
+			condition.RabbitMqTransportURLReadyRunningMessage))
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 	l.Info(fmt.Sprintf("TransportURL secret name %s", transportURL.Status.SecretName))
-	instance.Status.Conditions.MarkTrue(keystonev1.KeystoneRabbitMQTransportURLReadyCondition, keystonev1.KeystoneRabbitMQTransportURLReadyMessage)
+	instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
 	// run check rabbitmq - end
 
 	//

--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
-	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 )
 
@@ -170,7 +169,7 @@ var _ = Describe("Keystone controller", func() {
 			th.ExpectCondition(
 				keystoneApiName,
 				ConditionGetterFunc(KeystoneConditionGetter),
-				keystonev1.KeystoneRabbitMQTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionFalse,
 			)
 			th.ExpectCondition(
@@ -212,7 +211,7 @@ var _ = Describe("Keystone controller", func() {
 			th.ExpectCondition(
 				keystoneApiName,
 				ConditionGetterFunc(KeystoneConditionGetter),
-				keystonev1.KeystoneRabbitMQTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(
@@ -270,7 +269,7 @@ var _ = Describe("Keystone controller", func() {
 			th.ExpectCondition(
 				keystoneApiName,
 				ConditionGetterFunc(KeystoneConditionGetter),
-				keystonev1.KeystoneRabbitMQTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionTrue,
 			)
 			th.ExpectCondition(


### PR DESCRIPTION
Removes KeystoneRabbitMQTransportURLReadyCondition to use the condition.RabbitMqTransportURLReadyCondition from lib-common instead.