### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/templates/keystoneapi/config/keystone-api-config.json
+++ b/templates/keystoneapi/config/keystone-api-config.json
@@ -52,6 +52,12 @@
             "dest": "/etc/keystone/",
             "owner": "keystone:keystone",
             "perm": "0700"
+        },
+        {
+            "source": "/var/lib/config-data/default/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "keystone",
+            "perm": "0644"
         }
     ]
 }

--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -374,13 +374,16 @@ var _ = Describe("Keystone controller", func() {
 			)
 		})
 
-		It("should create a Secret for keystone.conf", func() {
+		It("should create a Secret for keystone.conf and my.cnf", func() {
 			scrt := th.GetSecret(keystoneApiConfigDataName)
 			configData := string(scrt.Data["keystone.conf"])
 			Expect(configData).To(
 				ContainSubstring("memcache_servers=memcached-0.memcached:11211,memcached-1.memcached:11211,memcached-2.memcached:11211"))
 			Expect(configData).To(
-				ContainSubstring(fmt.Sprintf("connection=mysql+pymysql://keystone:12345678@hostname-for-openstack.%s.svc/keystone", namespace)))
+				ContainSubstring(fmt.Sprintf("connection=mysql+pymysql://keystone:12345678@hostname-for-openstack.%s.svc/keystone?read_default_file=/etc/my.cnf", namespace)))
+			configData = string(scrt.Data["my.cnf"])
+			Expect(configData).To(
+				ContainSubstring("[client]\nssl=0"))
 		})
 		It("should create a Secret for fernet keys", func() {
 			th.GetSecret(types.NamespacedName{
@@ -904,13 +907,16 @@ var _ = Describe("Keystone controller", func() {
 			th.AssertVolumeMountExists(caBundleSecretName.Name, "tls-ca-bundle.pem", j.Spec.Template.Spec.Containers[0].VolumeMounts)
 		})
 
-		It("should create a Secret for keystone.conf", func() {
+		It("should create a Secret for keystone.conf and my.cnf", func() {
 			scrt := th.GetSecret(keystoneApiConfigDataName)
 			configData := string(scrt.Data["keystone.conf"])
 			Expect(configData).To(
 				ContainSubstring("memcache_servers=memcached-0.memcached:11211,memcached-1.memcached:11211,memcached-2.memcached:11211"))
 			Expect(configData).To(
-				ContainSubstring(fmt.Sprintf("connection=mysql+pymysql://keystone:12345678@hostname-for-openstack.%s.svc/keystone", namespace)))
+				ContainSubstring(fmt.Sprintf("connection=mysql+pymysql://keystone:12345678@hostname-for-openstack.%s.svc/keystone?read_default_file=/etc/my.cnf", namespace)))
+			configData = string(scrt.Data["my.cnf"])
+			Expect(configData).To(
+				ContainSubstring("[client]\nssl-ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\nssl=1"))
 		})
 
 		It("it creates deployment with CA and service certs mounted", func() {


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)