### PR TITLE
Enforcing scope with SRBAC breaks heat

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -84,11 +84,6 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
-              enableSecureRBAC:
-                default: true
-                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
-                  policies
-                type: boolean
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.
@@ -365,6 +360,12 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone AdminPassword
                 type: string
+              secureRBACEnforceNewDefaults:
+                default: true
+                type: boolean
+              secureRBACEnforceScope:
+                default: false
+                type: boolean
               tls:
                 description: TLS - Parameters related to the TLS
                 properties:

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -100,9 +100,12 @@ type KeystoneAPISpecCore struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	SecureRBACEnforceScope bool `json:"secureRBACEnforceScope"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=true
-	// EnableSecureRBAC - Enable Consistent and Secure RBAC policies
-	EnableSecureRBAC bool `json:"enableSecureRBAC"`
+	SecureRBACEnforceNewDefaults bool `json:"secureRBACEnforceNewDefaults"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=""

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -84,11 +84,6 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
-              enableSecureRBAC:
-                default: true
-                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
-                  policies
-                type: boolean
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.
@@ -365,6 +360,12 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone AdminPassword
                 type: string
+              secureRBACEnforceNewDefaults:
+                default: true
+                type: boolean
+              secureRBACEnforceScope:
+                default: false
+                type: boolean
               tls:
                 description: TLS - Parameters related to the TLS
                 properties:

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -1163,7 +1163,8 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 			instance.Status.DatabaseHostname,
 			keystone.DatabaseName,
 		),
-		"enableSecureRBAC": instance.Spec.EnableSecureRBAC,
+		"EnforceScope":       instance.Spec.SecureRBACEnforceScope,
+		"EnforceNewDefaults": instance.Spec.SecureRBACEnforceNewDefaults,
 	}
 
 	// create httpd  vhost template parameters

--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -13,8 +13,8 @@ db_max_retries=-1
 connection={{ .DatabaseConnection }}
 
 [oslo_policy]
-enforce_new_defaults = {{ .enableSecureRBAC }}
-enforce_scope = {{ .enableSecureRBAC }}
+enforce_new_defaults = {{ .EnforceNewDefaults }}
+enforce_scope = {{ .EnforceScope }}
 
 [fernet_tokens]
 key_repository=/etc/keystone/fernet-keys


### PR DESCRIPTION
Heat won't work when scope is enforced and it's being used by many of our NFV customers. Rather than making a single property to enable SRBAC, let's split them so that `enforce_new_defaults` can be set to true by default and customers can toggle `enforce_scope` if they're not using heat.

jira: https://issues.redhat.com/browse/OSPRH-5753