### PR TITLE
Pin setup-envtest to c7e1dc9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.


### PR DESCRIPTION
kubernetes-sigs/controller-runtime#2693 broke the content provider while doing docker-build with following issue[1]

In order to unblock the CI, we are pinning
sigs.k8s.io/controller-runtime/tools/setup-envtest at previous working commit[2]

[1]. kubernetes-sigs/controller-runtime#2720
[2]. kubernetes-sigs/controller-runtime@c7e1dc9