### PR TITLE
Revert "Enforcing scope with SRBAC breaks heat"

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -84,6 +84,11 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
+              enableSecureRBAC:
+                default: true
+                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                  policies
+                type: boolean
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.
@@ -360,12 +365,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone AdminPassword
                 type: string
-              secureRBACEnforceNewDefaults:
-                default: true
-                type: boolean
-              secureRBACEnforceScope:
-                default: false
-                type: boolean
               tls:
                 description: TLS - Parameters related to the TLS
                 properties:

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -100,12 +100,9 @@ type KeystoneAPISpecCore struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
-	SecureRBACEnforceScope bool `json:"secureRBACEnforceScope"`
-
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=true
-	SecureRBACEnforceNewDefaults bool `json:"secureRBACEnforceNewDefaults"`
+	// EnableSecureRBAC - Enable Consistent and Secure RBAC policies
+	EnableSecureRBAC bool `json:"enableSecureRBAC"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=""

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -84,6 +84,11 @@ spec:
                   files. Those get added to the service config dir in /etc/<service>
                   . TODO: -> implement'
                 type: object
+              enableSecureRBAC:
+                default: true
+                description: EnableSecureRBAC - Enable Consistent and Secure RBAC
+                  policies
+                type: boolean
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.
@@ -360,12 +365,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   keystone AdminPassword
                 type: string
-              secureRBACEnforceNewDefaults:
-                default: true
-                type: boolean
-              secureRBACEnforceScope:
-                default: false
-                type: boolean
               tls:
                 description: TLS - Parameters related to the TLS
                 properties:

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -1170,8 +1170,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 			instance.Status.DatabaseHostname,
 			keystone.DatabaseName,
 		),
-		"EnforceScope":       instance.Spec.SecureRBACEnforceScope,
-		"EnforceNewDefaults": instance.Spec.SecureRBACEnforceNewDefaults,
+		"enableSecureRBAC": instance.Spec.EnableSecureRBAC,
 	}
 
 	// create httpd  vhost template parameters

--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -17,8 +17,8 @@ db_max_retries=-1
 connection={{ .DatabaseConnection }}
 
 [oslo_policy]
-enforce_new_defaults = {{ .EnforceNewDefaults }}
-enforce_scope = {{ .EnforceScope }}
+enforce_new_defaults = {{ .enableSecureRBAC }}
+enforce_scope = {{ .enableSecureRBAC }}
 
 [fernet_tokens]
 key_repository=/etc/keystone/fernet-keys


### PR DESCRIPTION
Reverts openstack-k8s-operators/keystone-operator#395

this is incorrect for 2 reasons

first we have an explicit design goal to not add feature flags to CRD for config options.
this patch violates that design goal

second disabling srbac is something that has to be done on all services together and its not planned ot be confiruable in any service.

we intend to require the new policies and scope enforcement and enable them for all adopted and greenfield deployments. openstack-k8s-operators/keystone-operator#395 is not inline with that goal.

Related: [OSPRH-1492](https://issues.redhat.com//browse/OSPRH-1492)