### PR TITLE
Add the security-approvers to the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@
 approvers:
   - ci-approvers
   - openstack-approvers
+  - security-approvers
 
 reviewers:
   - ci-approvers
   - openstack-approvers
+  - security-approvers


### PR DESCRIPTION
This should give the members of the security-approvers team the ability to merge code into keystone-operator.