### PR TITLE
Create cloudrc contents in openstack-config-secret

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -1280,8 +1280,10 @@ func (r *KeystoneAPIReconciler) reconcileCloudConfig(
 	if err != nil {
 		return err
 	}
+	cloudrc := keystone.GenerateCloudrc(&openStackConfigSecret, &openStackConfig)
 	secretString := map[string]string{
 		"secure.yaml": string(secretVal),
+		"cloudrc":     string(cloudrc),
 	}
 
 	secrets := []util.Template{

--- a/pkg/keystone/cloudconfig.go
+++ b/pkg/keystone/cloudconfig.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package keystone
 
+import "fmt"
+
 // OpenStackConfig type
 type OpenStackConfig struct {
 	Clouds struct {
@@ -41,4 +43,18 @@ type OpenStackConfigSecret struct {
 			}
 		}
 	}
+}
+
+// generateCloudrc - generate file contents of a cloudrc file for the clients
+// until there is parity with openstackclient.
+func GenerateCloudrc(secret *OpenStackConfigSecret, config *OpenStackConfig) string {
+	auth := config.Clouds.Default.Auth
+	val := fmt.Sprintf(
+		"export OS_AUTH_URL=" + auth.AuthURL +
+			"\nexport OS_USERNAME=" + auth.UserName +
+			"\nexport OS_PROJECT_NAME=" + auth.ProjectName +
+			"\nexport OS_PROJECT_DOMAIN_NAME=" + auth.ProjectDomainName +
+			"\nexport OS_USER_DOMAIN_NAME=" + auth.UserDomainName +
+			"\nexport OS_PASSWORD=" + secret.Clouds.Default.Auth.Password)
+	return val
 }


### PR DESCRIPTION
We are currently only creating the `clouds.yaml` and `secure.yaml` for the openstack client and not the classic `cloudrc` file that was usually sourced for individual clients.

This makes sense if there were parity between the openstck client and all the individual clients, but there are still missing features. For example:

- The `openstack volume service list` cannot show the cluster.
- The `openstack volume service list` cannot show the backend state.
- There is no support for any of the default volume type commands: set, show, list, unset.

These are some of the ones we know about, but there could be more.

Users will need to use the old `cinder` client, so we should make it convenient for them by having the `cloudrc` available in the `openstackclient` pod.

This patch adds the `cloudrc` key in the `openstack-config-secret` secret to make it possible for the `openstack-operator` to mount it in the `openstackclient` pod.