### PR TITLE
Add fernet key rotation cronjob

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -89,6 +89,20 @@ spec:
                 description: EnableSecureRBAC - Enable Consistent and Secure RBAC
                   policies
                 type: boolean
+              fernetMaxActiveKeys:
+                default: 5
+                description: FernetMaxActiveKeys - Maximum number of fernet token
+                  keys after rotation
+                format: int32
+                minimum: 3
+                type: integer
+              fernetRotationDays:
+                default: 1
+                description: FernetRotationDays - Rotate fernet token keys every X
+                  days
+                format: int32
+                minimum: 1
+                type: integer
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -120,6 +120,18 @@ type KeystoneAPISpecCore struct {
 	TrustFlushSuspend bool `json:"trustFlushSuspend"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=1
+	// FernetRotationDays - Rotate fernet token keys every X days
+	FernetRotationDays *int32 `json:"fernetRotationDays"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=5
+	// +kubebuilder:validation:Minimum=3
+	// FernetMaxActiveKeys - Maximum number of fernet token keys after rotation
+	FernetMaxActiveKeys *int32 `json:"fernetMaxActiveKeys"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={admin: AdminPassword}
 	// PasswordSelectors - Selectors to identify the AdminUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -147,6 +147,16 @@ func (in *KeystoneAPISpecCore) DeepCopyInto(out *KeystoneAPISpecCore) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.FernetRotationDays != nil {
+		in, out := &in.FernetRotationDays, &out.FernetRotationDays
+		*out = new(int32)
+		**out = **in
+	}
+	if in.FernetMaxActiveKeys != nil {
+		in, out := &in.FernetMaxActiveKeys, &out.FernetMaxActiveKeys
+		*out = new(int32)
+		**out = **in
+	}
 	out.PasswordSelectors = in.PasswordSelectors
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -89,6 +89,20 @@ spec:
                 description: EnableSecureRBAC - Enable Consistent and Secure RBAC
                   policies
                 type: boolean
+              fernetMaxActiveKeys:
+                default: 5
+                description: FernetMaxActiveKeys - Maximum number of fernet token
+                  keys after rotation
+                format: int32
+                minimum: 3
+                type: integer
+              fernetRotationDays:
+                default: 1
+                description: FernetRotationDays - Rotate fernet token keys every X
+                  days
+                format: int32
+                minimum: 1
+                type: integer
               memcachedInstance:
                 default: memcached
                 description: Memcached instance name.

--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -60,12 +60,12 @@ func BootstrapJob(
 	}
 
 	// create Volume and VolumeMounts
-	volumes := getVolumes(instance.Name)
+	volumes := getVolumes(instance)
 	volumeMounts := getVolumeMounts()
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {
-		volumes = append(getVolumes(instance.Name), instance.Spec.TLS.CreateVolume())
+		volumes = append(getVolumes(instance), instance.Spec.TLS.CreateVolume())
 		volumeMounts = append(getVolumeMounts(), instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 

--- a/pkg/keystone/const.go
+++ b/pkg/keystone/const.go
@@ -28,4 +28,9 @@ const (
 	KeystonePublicPort int32 = 5000
 	// KeystoneInternalPort -
 	KeystoneInternalPort int32 = 5000
+
+	// DefaultFernetMaxActiveKeys -
+	DefaultFernetMaxActiveKeys = 5
+	// DefaultFernetRotationDays -
+	DefaultFernetRotationDays = 1
 )

--- a/pkg/keystone/cronjob.go
+++ b/pkg/keystone/cronjob.go
@@ -46,12 +46,12 @@ func CronJob(
 	completions := int32(1)
 
 	// create Volume and VolumeMounts
-	volumes := getVolumes(instance.Name)
+	volumes := getVolumes(instance)
 	volumeMounts := getVolumeMounts()
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {
-		volumes = append(getVolumes(instance.Name), instance.Spec.TLS.CreateVolume())
+		volumes = append(getVolumes(instance), instance.Spec.TLS.CreateVolume())
 		volumeMounts = append(getVolumeMounts(), instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -45,12 +45,13 @@ func DbSyncJob(
 	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("true")
 
 	// create Volume and VolumeMounts
-	volumes := getVolumes(instance.Name)
+	volumes := getVolumes(instance)
 	volumeMounts := getVolumeMounts()
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {
-		volumes = append(getVolumes(instance.Name), instance.Spec.TLS.CreateVolume())
+		//TODO(afaranha): Why not reuse the 'volumes'?
+		volumes = append(getVolumes(instance), instance.Spec.TLS.CreateVolume())
 		volumeMounts = append(getVolumeMounts(), instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -80,7 +80,7 @@ func Deployment(
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
 	// create Volume and VolumeMounts
-	volumes := getVolumes(instance.Name)
+	volumes := getVolumes(instance)
 	volumeMounts := getVolumeMounts()
 
 	// add CA cert if defined

--- a/pkg/keystone/fernet.go
+++ b/pkg/keystone/fernet.go
@@ -17,7 +17,6 @@ package keystone
 
 import (
 	"encoding/base64"
-
 	"math/rand"
 )
 

--- a/pkg/keystone/volumes.go
+++ b/pkg/keystone/volumes.go
@@ -16,13 +16,29 @@ limitations under the License.
 package keystone
 
 import (
+	"fmt"
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // getVolumes - service volumes
-func getVolumes(name string) []corev1.Volume {
+func getVolumes(instance *keystonev1.KeystoneAPI) []corev1.Volume {
+	name := instance.Name
 	var scriptsVolumeDefaultMode int32 = 0755
 	var config0640AccessMode int32 = 0640
+
+	fernetKeys := []corev1.KeyToPath{}
+	numberKeys := int(*instance.Spec.FernetMaxActiveKeys)
+
+	for i := 0; i < numberKeys; i++ {
+		fernetKeys = append(
+			fernetKeys,
+			corev1.KeyToPath{
+				Key:  fmt.Sprintf("FernetKeys%d", i),
+				Path: fmt.Sprintf("%d", i),
+			},
+		)
+	}
 
 	return []corev1.Volume{
 		{
@@ -48,16 +64,7 @@ func getVolumes(name string) []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: ServiceName,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "FernetKeys0",
-							Path: "0",
-						},
-						{
-							Key:  "FernetKeys1",
-							Path: "1",
-						},
-					},
+					Items:      fernetKeys,
 				},
 			},
 		},

--- a/tests/kuttl/tests/keystone_tls/01-assert.yaml
+++ b/tests/kuttl/tests/keystone_tls/01-assert.yaml
@@ -88,6 +88,12 @@ spec:
             path: "0"
           - key: FernetKeys1
             path: "1"
+          - key: FernetKeys2
+            path: "2"
+          - key: FernetKeys3
+            path: "3"
+          - key: FernetKeys4
+            path: "4"
           secretName: keystone
       - name: credential-keys
         secret:


### PR DESCRIPTION
As part of this work, we needed to implement more than 2 keys, since rotating 2 would expire sessions on every rotation. There are new settings and the defaults are the same as in "old-gen" Tripelo.

jira: [OSPRH-9309](https://issues.redhat.com//browse/OSPRH-9309)