### PR TITLE
[make]Add force-bump target to bump operator deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,3 +370,14 @@ run-with-webhook: export METRICS_PORT?=8080
 run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/run_with_local_webhook.sh
+
+
+BRANCH=main
+.PHONY: force-bump
+force-bump: ## Force bump operator and lib-common dependencies
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|keystone-operator|^replace' | awk '{print $$1}'); do \
+		go get $$dep@$(BRANCH) ; \
+	done
+	for dep in $$(cat api/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|keystone-operator|^replace' | awk '{print $$1}'); do \
+		cd ./api && go get $$dep@$(BRANCH) && cd .. ; \
+	done


### PR DESCRIPTION
The new force-bump target bumps operator and lib-common dependencies of
this operator by tracking the same branch from these dependencies.

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)
