### PR TITLE
[18.0-fr1][make]Add force-bump target to bump operator deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,3 +370,13 @@ run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
+
+BRANCH=18.0-fr1
+.PHONY: force-bump
+force-bump: ## Force bump operator and lib-common dependencies
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|keystone-operator|^replace' | awk '{print $$1}'); do \
+		go get $$dep@$(BRANCH) ; \
+	done
+	for dep in $$(cat api/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|keystone-operator|^replace' | awk '{print $$1}'); do \
+		cd ./api && go get $$dep@$(BRANCH) && cd .. ; \
+	done


### PR DESCRIPTION
The new force-bump target bumps operator and lib-common dependencies of this operator by tracking the same branch from these dependencies.

18.0-fr1 only change:

* resolve the merge conflict in Makefile due to 20ea95d is not in 18.0-fr1
* switched the branch target of force-bump to 18.0-fr1

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)
(cherry picked from commit 446790da4fd40a7dd0eb4f5f347352e6042614c3)