### PR TITLE
[18.0-fr1][renovate]Run make force-dep

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,11 @@
 {
   "extends": [
-    "github>openstack-k8s-operators/renovate-config:default.json5"
+    "github>openstack-k8s-operators/renovate-config:stable.json5"
   ],
   "baseBranches": ["main"],
   "useBaseBranchConfig": "merge",
+  "commitMessageExtra": "",
+  "prBodyColumns": ["Package"],
   "packageRules": [
     {
       "matchPackageNames": ["github.com/openstack-k8s-operators/keystone-operator/api"],
@@ -11,8 +13,14 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["make gowork", "make tidy", "make manifests generate"],
+    "commands": [
+        "git reset --hard HEAD",
+        "make force-bump",
+        "make gowork",
+        "make tidy",
+        "make manifests generate"
+    ],
     "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
-    "executionMode": "update"
+    "executionMode": "branch"
   }
 }


### PR DESCRIPTION
Renovate cannot follow dep version based on branching. So this hack runs make force-bump as a post update task in renovate run. That make target ensures that dependencies from openstack-k8s-operator org are bumped according to the current branch, 18.0-fr1.

Note that git reset --hard HEAD is needed before make force-bump as at this point renovate already bumped all the dependencies based pseudoversions and this could mean that transitively bumped the versions of modules outside of openstack-k8s-operators, e.g. k8s.io. The make force-bump only pulls the openstack-k8s-operators dependencies based on the branch but it won't pull back other deps like k8s.io. So git reset is used to create a clean slate.

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)