### PR TITLE
Fix default cache config for no tls

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -1186,9 +1186,10 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	dbSecret := db.GetSecret()
 
 	templateParameters := map[string]interface{}{
-		"memcachedServers": mc.GetMemcachedServerListString(),
-		"memcachedTLS":     mc.GetMemcachedTLSSupport(),
-		"TransportURL":     string(transportURLSecret.Data["transport_url"]),
+		"memcachedServers":         mc.GetMemcachedServerListString(),
+		"memcachedServersWithInet": mc.GetMemcachedServerListWithInetString(),
+		"memcachedTLS":             mc.GetMemcachedTLSSupport(),
+		"TransportURL":             string(transportURLSecret.Data["transport_url"]),
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(dbSecret.Data[mariadbv1.DatabasePasswordSelector]),

--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -4,11 +4,12 @@ use_stderr=true
 [cache]
 {{if .memcachedTLS}}
 backend = dogpile.cache.pymemcache
+memcache_servers={{ .memcachedServers }}
 {{else}}
 backend = dogpile.cache.memcached
+memcache_servers={{ .memcachedServersWithInet }}
 {{end}}
 enabled=true
-memcache_servers={{ .memcachedServers }}
 tls_enabled={{ .memcachedTLS }}
 
 [database]

--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -404,7 +404,9 @@ var _ = Describe("Keystone controller", func() {
 			scrt := th.GetSecret(keystoneAPIConfigDataName)
 			configData := string(scrt.Data["keystone.conf"])
 			Expect(configData).To(
-				ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
+				ContainSubstring("backend = dogpile.cache.memcached"))
+			Expect(configData).To(
+				ContainSubstring(fmt.Sprintf("memcache_servers=inet:[memcached-0.memcached.%s.svc]:11211,inet:[memcached-1.memcached.%s.svc]:11211,inet:[memcached-2.memcached.%s.svc]:11211",
 					keystoneAPIName.Namespace, keystoneAPIName.Namespace, keystoneAPIName.Namespace)))
 			mariadbAccount := mariadb.GetMariaDBAccount(keystoneAccountName)
 			mariadbSecret := th.GetSecret(types.NamespacedName{Name: mariadbAccount.Spec.Secret, Namespace: keystoneAPIName.Namespace})
@@ -853,7 +855,7 @@ var _ = Describe("Keystone controller", func() {
 				Name:      fmt.Sprintf("%s-keystone-transport", keystoneAPIName.Name),
 				Namespace: namespace,
 			})
-			infra.SimulateMemcachedReady(types.NamespacedName{
+			infra.SimulateTLSMemcachedReady(types.NamespacedName{
 				Name:      "memcached",
 				Namespace: namespace,
 			})
@@ -947,6 +949,8 @@ var _ = Describe("Keystone controller", func() {
 		It("should create a Secret for keystone.conf and my.cnf", func() {
 			scrt := th.GetSecret(keystoneAPIConfigDataName)
 			configData := string(scrt.Data["keystone.conf"])
+			Expect(configData).To(
+				ContainSubstring("backend = dogpile.cache.pymemcache"))
 			Expect(configData).To(
 				ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
 					keystoneAPIName.Namespace, keystoneAPIName.Namespace, keystoneAPIName.Namespace)))


### PR DESCRIPTION
When env is deployed with tls disabled, cache config was wrong as "dogpile.cache.memcached" backend requires inet[6] prefixes for memcache_servers setting while it was set without the prefix.

With IPv4 issue not observed as "inet" is default prefix, this patch fixes it by setting [cache]/memcache_servers based on tls config.

Resolves: [OSPRH-12222](https://issues.redhat.com//browse/OSPRH-12222)
Related-Issue: [OSPRH-12221](https://issues.redhat.com//browse/OSPRH-12221)