### PR TITLE
Modified CreateKeystoneAPI to take an additional parameter spec

### DIFF
--- a/api/test/helpers/crd.go
+++ b/api/test/helpers/crd.go
@@ -65,7 +65,11 @@ func (th *TestHelper) CreateKeystoneAPI(namespace string) types.NamespacedName {
 			Name:      "keystone-" + uuid.New().String(),
 			Namespace: namespace,
 		},
-		Spec: keystonev1.KeystoneAPISpec{},
+		Spec: keystonev1.KeystoneAPISpec{
+			KeystoneAPISpecCore: keystonev1.KeystoneAPISpecCore{
+				APITimeout: 60,
+			},
+		},
 	}
 
 	gomega.Expect(th.K8sClient.Create(th.Ctx, keystone.DeepCopy())).Should(gomega.Succeed())


### PR DESCRIPTION
This change will fix all func tests in operators without any additional changes required.

Currently tests are failing in renovate bump patches https://github.com/openstack-k8s-operators/nova-operator/pull/918 . Problem is with defaulting APITimeout, webhook is failing when spec is empty.  Unfortunattly other option with using Unstruct is required much more changes inside the function and also in other operators test suite to add keystone defaulting