### PR TITLE
Fix missing APITimeout in CreateKeystoneAPIWithFixture

### DIFF
--- a/api/test/helpers/crd.go
+++ b/api/test/helpers/crd.go
@@ -120,6 +120,7 @@ func (th *TestHelper) CreateKeystoneAPIWithFixture(
 				PasswordSelectors: keystonev1.PasswordSelector{
 					Admin: "admin-password",
 				},
+				APITimeout: 60,
 			},
 		},
 	}


### PR DESCRIPTION
CreateKeystoneAPIWtithFixture doesn't set the APITimeout The other operators which use this function see an error:

  KeystoneAPI.keystone.openstack.org ... is invalid: spec.apiTimeout:
  Invalid value: 0: spec.apiTimeout in body should be greater than or
  equal to 10

Note: this function is not called by keystone-operator but it is used by the octavia-operator.