### PR TITLE
Add config for Domain-specific LDAP Backends

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -93,6 +93,12 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              domainConfigSecret:
+                default: ""
+                description: |-
+                  The OpenShift secret that stores the domain configuration.
+                  These will be mounted to /etc/keystone/domains
+                type: string
               enableSecureRBAC:
                 default: true
                 description: EnableSecureRBAC - Enable Consistent and Secure RBAC

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -167,6 +167,12 @@ type KeystoneAPISpecCore struct {
 	// HttpdCustomization - customize the httpd service
 	HttpdCustomization HttpdCustomization `json:"httpdCustomization"`
 
+        // +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+        // The OpenShift secret that stores the domain configuration.
+        // These will be mounted to /etc/keystone/domains
+        DomainConfigSecret string `json:"domainConfigSecret"`
+
 	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -93,6 +93,12 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              domainConfigSecret:
+                default: ""
+                description: |-
+                  The OpenShift secret that stores the domain configuration.
+                  These will be mounted to /etc/keystone/domains
+                type: string
               enableSecureRBAC:
                 default: true
                 description: EnableSecureRBAC - Enable Consistent and Secure RBAC

--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -61,12 +61,12 @@ func BootstrapJob(
 
 	// create Volume and VolumeMounts
 	volumes := getVolumes(instance)
-	volumeMounts := getVolumeMounts()
+	volumeMounts := getVolumeMounts(instance)
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		volumes = append(getVolumes(instance), instance.Spec.TLS.CreateVolume())
-		volumeMounts = append(getVolumeMounts(), instance.Spec.TLS.CreateVolumeMounts(nil)...)
+		volumeMounts = append(getVolumeMounts(instance), instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
 	job := &batchv1.Job{

--- a/pkg/keystone/cronjob.go
+++ b/pkg/keystone/cronjob.go
@@ -47,12 +47,12 @@ func CronJob(
 
 	// create Volume and VolumeMounts
 	volumes := getVolumes(instance)
-	volumeMounts := getVolumeMounts()
+	volumeMounts := getVolumeMounts(instance)
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		volumes = append(getVolumes(instance), instance.Spec.TLS.CreateVolume())
-		volumeMounts = append(getVolumeMounts(), instance.Spec.TLS.CreateVolumeMounts(nil)...)
+		volumeMounts = append(getVolumeMounts(instance), instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
 	cronjob := &batchv1.CronJob{

--- a/pkg/keystone/dbsync.go
+++ b/pkg/keystone/dbsync.go
@@ -46,13 +46,13 @@ func DbSyncJob(
 
 	// create Volume and VolumeMounts
 	volumes := getVolumes(instance)
-	volumeMounts := getVolumeMounts()
+	volumeMounts := getVolumeMounts(instance)
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		//TODO(afaranha): Why not reuse the 'volumes'?
 		volumes = append(getVolumes(instance), instance.Spec.TLS.CreateVolume())
-		volumeMounts = append(getVolumeMounts(), instance.Spec.TLS.CreateVolumeMounts(nil)...)
+		volumeMounts = append(getVolumeMounts(instance), instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
 	job := &batchv1.Job{

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -83,7 +83,7 @@ func Deployment(
 
 	// create Volume and VolumeMounts
 	volumes := getVolumes(instance)
-	volumeMounts := getVolumeMounts()
+	volumeMounts := getVolumeMounts(instance)
 
 	// add CA cert if defined
 	if instance.Spec.TLS.CaBundleSecretName != "" {


### PR DESCRIPTION
This mounts the provided secret as a volume into
/etc/keystone/domains.
