### PR TITLE
[golang] bump to golang 1.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.22-sdk-1.31

--- a/.github/workflows/build-keystone-operator.yaml
+++ b/.github/workflows/build-keystone-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: keystone
-      go_version: 1.21.x
+      go_version: 1.22.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v1.63.4
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.22
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,10 @@ tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy
 	cd ./api && go mod tidy
 
+GOLANGCI_LINT_VERSION ?= v1.63.4
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix --verbose
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
@@ -206,7 +207,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.22.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/keystone-operator/api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/keystone-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v1.63.4
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.22-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.22
* delete current `go.work*` files
* init go work files `go work init`

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1051
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1411