### PR TITLE
Change memcache to use memcache_pool driver

### DIFF
--- a/templates/keystoneapi/config/keystone.conf
+++ b/templates/keystoneapi/config/keystone.conf
@@ -3,16 +3,19 @@ use_stderr=true
 
 [cache]
 {{if .MemcachedTLS}}
-backend = dogpile.cache.pymemcache
+backend = oslo_cache.memcache_pool
 memcache_servers={{ .MemcachedServers }}
-enable_retry_client = true
-retry_attempts = 2
-retry_delay = 0
+memcache_socket_timeout = 0.5
+memcache_pool_connection_get_timeout = 1
+# workaround to force bmemcache driver
+memcache_sasl_enable = true
+# this is needed to override the default set by the operator
+enable_retry_client = false
 {{else}}
 backend = dogpile.cache.memcached
 memcache_servers={{ .MemcachedServersWithInet }}
-memcache_dead_retry = 10
 {{end}}
+memcache_dead_retry = 30
 enabled=true
 tls_enabled={{ .MemcachedTLS }}
 

--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -1067,7 +1067,7 @@ var _ = Describe("Keystone controller", func() {
 			scrt := th.GetSecret(keystoneAPIConfigDataName)
 			configData := string(scrt.Data["keystone.conf"])
 			Expect(configData).To(
-				ContainSubstring("backend = dogpile.cache.pymemcache"))
+				ContainSubstring("backend = oslo_cache.memcache_pool"))
 			Expect(configData).To(
 				ContainSubstring(fmt.Sprintf("memcache_servers=memcached-0.memcached.%s.svc:11211,memcached-1.memcached.%s.svc:11211,memcached-2.memcached.%s.svc:11211",
 					keystoneAPIName.Namespace, keystoneAPIName.Namespace, keystoneAPIName.Namespace)))


### PR DESCRIPTION
In HA tests it was identified that pymemcache backend does not recover/fail over to the next memcache instance when one goes away unexpected. Using memcache_pool with bmemcache does failover properly.

The memcache_sasl_enable=true is a workaround to force oslo.cache to switch to the bmemcache driver, which is the only driver in memcache_pool supporting tls+fips.

Jira: [OSPRH-16651](https://issues.redhat.com//browse/OSPRH-16651)

Co-outhored-by: Luca Miccini <lmiccini@redhat.com>