### PR TITLE
Add KeystoneAPIStatusChangedPredicate to help watch KeystoneAPI status to reconcile on endpoint changes

### DIFF
--- a/api/test/helpers/crd.go
+++ b/api/test/helpers/crd.go
@@ -142,6 +142,22 @@ func (th *TestHelper) CreateKeystoneAPIWithFixture(
 	return name
 }
 
+// UpdateKeystoneAPIEndpoint updates a KeystoneAPI resource from the Kubernetes cluster adds a key
+// or updates an existing key in the Spec.Endpoints with a value
+//
+// Example usage:
+//
+//	th.UpdateKeystoneAPIEndpoint(endpointName, key, value)
+func (th *TestHelper) UpdateKeystoneAPIEndpoint(name types.NamespacedName, key string, newValue string) {
+	gomega.Eventually(func(g gomega.Gomega) {
+		keystone := th.GetKeystoneAPI(name)
+
+		keystone.Status.APIEndpoints[key] = newValue
+		g.Expect(th.K8sClient.Status().Update(th.Ctx, keystone.DeepCopy())).Should(gomega.Succeed())
+	}, th.Timeout, th.Interval).Should(gomega.Succeed())
+	th.Logger.Info("KeystoneAPI Endpoint updated", "keystoneAPI", name.Name, "key", key)
+}
+
 // DeleteKeystoneAPI deletes a KeystoneAPI resource from the Kubernetes cluster.
 //
 // # After the deletion, the function checks again if the KeystoneAPI is successfully deleted


### PR DESCRIPTION
Adds KeystoneAPIStatusChangedPredicate where its primary purpose is to return true if the KeystoneAPI Status.APIEndpoints has changed.

In addition also returns true if it gets deleted, which is unlikely to happen since keystone is a requirement for other services to work properly. Used by service operators to watch KeystoneAPI endpoint they depend on.
    
Jira: [OSPRH-16994](https://issues.redhat.com//browse/OSPRH-16994)