### PR TITLE
Add support for multi-realm federation config

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1162,6 +1162,16 @@ spec:
                   - extraVol
                   type: object
                 type: array
+              federatedRealmConfig:
+                description: |-
+                  Secret containing the configuration for federated realms
+                  This is only needed when multiple realms are federated.
+                type: string
+              federationMountPath:
+                description: |-
+                  Mount path for federation config files
+                  This is only needed when multiple realms are federated.
+                type: string
               fernetMaxActiveKeys:
                 default: 5
                 description: FernetMaxActiveKeys - Maximum number of fernet token

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -206,6 +206,16 @@ type KeystoneAPISpecCore struct {
 	// ExtraMounts containing conf files
 	// +kubebuilder:default={}
 	ExtraMounts []KeystoneExtraMounts `json:"extraMounts,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// Secret containing the configuration for federated realms
+	// This is only needed when multiple realms are federated.
+	FederatedRealmConfig string `json:"federatedRealmConfig"`
+
+	// +kubebuilder:validation:Optional
+	// Mount path for federation config files
+	// This is only needed when multiple realms are federated.
+	FederationMountPath string `json:"federationMountPath"`
 }
 
 // APIOverrideSpec to override the generated manifest of several child resources.

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1162,6 +1162,16 @@ spec:
                   - extraVol
                   type: object
                 type: array
+              federatedRealmConfig:
+                description: |-
+                  Secret containing the configuration for federated realms
+                  This is only needed when multiple realms are federated.
+                type: string
+              federationMountPath:
+                description: |-
+                  Mount path for federation config files
+                  This is only needed when multiple realms are federated.
+                type: string
               fernetMaxActiveKeys:
                 default: 5
                 description: FernetMaxActiveKeys - Maximum number of fernet token

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -17,7 +17,10 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"time"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -923,6 +926,20 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	}
 
 	//
+	// Create secret holding federation realm config (for multiple realms)
+	//
+	federationFilenames, err := r.ensureFederationRealmConfig(ctx, instance, helper)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+
+	//
 	// TLS input validation
 	//
 	// Validate the CA cert secret if provided
@@ -1101,7 +1118,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	//
 
 	// Define a new Deployment object
-	deplDef, err := keystone.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology)
+	deplDef, err := keystone.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology, federationFilenames)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
@@ -1608,6 +1625,92 @@ func (r *KeystoneAPIReconciler) ensureFernetKeys(
 	}
 
 	return nil
+}
+
+// ensureFederationRealmConfig - create secret with federation realm config
+// only used for multiple realm configuration
+// returns the array of sorted filenames
+func (r *KeystoneAPIReconciler) ensureFederationRealmConfig(
+	ctx context.Context,
+	instance *keystonev1.KeystoneAPI,
+	helper *helper.Helper,
+) ([]string, error) {
+	logger := r.GetLogger(ctx)
+
+	if instance.Spec.FederatedRealmConfig == "" {
+		return nil, nil
+	}
+
+	// get the data from the relevant secret
+	// we expect this to be a JSON dict
+	jsonData, _, err := oko_secret.GetDataFromSecret(
+		ctx,
+		helper,
+		instance.Spec.FederatedRealmConfig,
+		10*time.Second,
+		keystone.FederationConfigKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the JSON content into a map
+	var rawConfigs map[string]json.RawMessage
+	err = json.Unmarshal([]byte(jsonData), &rawConfigs)
+	if err != nil {
+		logger.Error(err, "Failed to unmarshal nested JSON from 'federation_config.json'")
+		return nil, err
+	}
+
+	// Extract and Sort Filenames (Keys)
+	var sortedFilenames []string
+	for filename := range rawConfigs {
+		sortedFilenames = append(sortedFilenames, filename)
+	}
+	sort.Strings(sortedFilenames)
+
+	// Prepare data for the new Secret
+	newSecretData := make(map[string]string)
+
+	// Iterate through the *sorted* filenames to populate the new Secret
+	for index, filename := range sortedFilenames {
+		// Get the raw content for the current filename
+		content, ok := rawConfigs[filename]
+		if !ok {
+			// logger.Warning("Warning: Content for sorted filename '%s' not found in rawConfigs. Skipping.", filename)
+			continue
+		}
+
+		newSecretData[strconv.Itoa(index)] = string(content) // Use sorted index as key
+	}
+
+	// Store the *sorted* original filenames as a JSON array in a special key
+	filenamesJSON, err := json.Marshal(sortedFilenames)
+	if err != nil {
+		logger.Error(err, "Failed to marshal sorted filenames")
+		return nil, err
+	}
+	newSecretData["_filenames.json"] = string(filenamesJSON)
+
+	templateParameters := make(map[string]interface{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(keystone.ServiceName), map[string]string{})
+	newSecret := []util.Template{
+		{
+			Name:          keystone.FederationMultiRealmSecret,
+			Namespace:     instance.Namespace,
+			Type:          util.TemplateTypeNone,
+			InstanceType:  instance.Kind,
+			CustomData:    newSecretData,
+			ConfigOptions: templateParameters,
+			Labels:        cmLabels,
+		},
+	}
+
+	err = oko_secret.EnsureSecrets(ctx, helper, instance, newSecret, nil)
+	if err != nil {
+		logger.Error(err, "Failed to create new secret")
+		return nil, err
+	}
+	return sortedFilenames, nil
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/pkg/keystone/const.go
+++ b/pkg/keystone/const.go
@@ -47,6 +47,10 @@ const (
 	KeystoneCronJob storage.PropagationType = "KeystoneCron"
 	// KeystoneBootstrap is the bootstrap service
 	KeystoneBootstrap storage.PropagationType = "KeystoneBootstrap"
+	// FederationConfigKey - key for multi-realm federation config secret
+	FederationConfigKey = "federation-config.json"
+	// FederationMultiRealmSecret - secret to store processed multirealm data
+	FederationMultiRealmSecret = "keystone-multirealm-federation-secret"
 )
 
 // KeystoneAPIPropagation is the  definition of the Horizon propagation service

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -42,6 +42,7 @@ func Deployment(
 	labels map[string]string,
 	annotations map[string]string,
 	topology *topologyv1.Topology,
+	federationFilenames []string,
 ) (*appsv1.Deployment, error) {
 
 	livenessProbe := &corev1.Probe{
@@ -88,6 +89,12 @@ func Deployment(
 	if instance.Spec.TLS.CaBundleSecretName != "" {
 		volumes = append(volumes, instance.Spec.TLS.CreateVolume())
 		volumeMounts = append(volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
+	}
+
+	// add Federation volumes and volume mounts if needed
+	if instance.Spec.FederatedRealmConfig != "" {
+		volumes = append(volumes, getFederationVolumes(federationFilenames)...)
+		volumeMounts = append(volumeMounts, getFederationVolumeMounts(instance.Spec.FederationMountPath, federationFilenames)...)
 	}
 
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {

--- a/pkg/keystone/federation.go
+++ b/pkg/keystone/federation.go
@@ -1,0 +1,64 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"path/filepath"
+	"strconv"
+)
+
+// getFederationVolumeMounts - get federation mountpoints
+func getFederationVolumeMounts(
+	federationMountPath string,
+	federationFilenames []string,
+) []corev1.VolumeMount {
+	vms := []corev1.VolumeMount{}
+
+	for index, filename := range federationFilenames {
+		vm := corev1.VolumeMount{
+			Name:      "federation-realm-volume" + strconv.Itoa(index),
+			MountPath: filepath.Join(federationMountPath, filename),
+			SubPath:   strconv.Itoa(index),
+			ReadOnly:  true,
+		}
+		vms = append(vms, vm)
+	}
+
+	return vms
+}
+
+// getFederationVolumes - get federation volumes
+func getFederationVolumes(
+	federationFilenames []string,
+) []corev1.Volume {
+	var config0640AccessMode int32 = 0644
+	vols := []corev1.Volume{}
+
+	for index := range federationFilenames {
+		vol := corev1.Volume{
+			Name: "federation-realm-volume" + strconv.Itoa(index),
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: &config0640AccessMode,
+					SecretName:  FederationMultiRealmSecret,
+				},
+			},
+		}
+		vols = append(vols, vol)
+	}
+	return vols
+}


### PR DESCRIPTION
It would be great to use something like extraVols to configure multi-realm federation.  Unfortunately, the config files for multi-realm - which need to be stored in a secret because they contain some sensitive data - have filenames that have URL encodings, making them invalid as keys in a k8s secret.

So, we have to resort to some trickery to get the right files mounted.  The solution is as follows:
1. User provides a secret which contains the contents {key, json map containing filenames and contents}
2. We parse the contents of that secret and create a new secret which has valid keys (1,2,3 .. etc) and the relevant contents based on an ordered list of the filenames.
3. We create the mounts and mountpoints as appropriate.