### PR TITLE
Use kolla for mounting multi-realm federation config files

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1166,12 +1166,7 @@ spec:
                 description: |-
                   Secret containing the configuration for federated realms
                   This is only needed when multiple realms are federated.
-                type: string
-              federationMountPath:
-                description: |-
-                  Mount path for federation config files
-                  This is only needed when multiple realms are federated.
-                  If not specified, "/etc/httpd/conf" is used
+                  Config files mount path is set to /etc/httpd/conf/
                 type: string
               fernetMaxActiveKeys:
                 default: 5

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -210,13 +210,8 @@ type KeystoneAPISpecCore struct {
 	// +kubebuilder:validation:Optional
 	// Secret containing the configuration for federated realms
 	// This is only needed when multiple realms are federated.
+	// Config files mount path is set to /etc/httpd/conf/
 	FederatedRealmConfig string `json:"federatedRealmConfig"`
-
-	// +kubebuilder:validation:Optional
-	// Mount path for federation config files
-	// This is only needed when multiple realms are federated.
-	// If not specified, "/etc/httpd/conf" is used
-	FederationMountPath string `json:"federationMountPath"`
 }
 
 // APIOverrideSpec to override the generated manifest of several child resources.

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1166,12 +1166,7 @@ spec:
                 description: |-
                   Secret containing the configuration for federated realms
                   This is only needed when multiple realms are federated.
-                type: string
-              federationMountPath:
-                description: |-
-                  Mount path for federation config files
-                  This is only needed when multiple realms are federated.
-                  If not specified, "/etc/httpd/conf" is used
+                  Config files mount path is set to /etc/httpd/conf/
                 type: string
               fernetMaxActiveKeys:
                 default: 5

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -928,10 +928,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	//
 	// Create secret holding federation realm config (for multiple realms)
 	//
-	// If the user has provided a multi-realm federation config but no mountPath, default it
-	if instance.Spec.FederatedRealmConfig != "" && instance.Spec.FederationMountPath == "" {
-		instance.Spec.FederationMountPath = keystone.FederationDefaultMountPath
-	}
+
 	federationFilenames, err := r.ensureFederationRealmConfig(ctx, instance, helper, &configMapVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/pkg/keystone/const.go
+++ b/pkg/keystone/const.go
@@ -52,7 +52,7 @@ const (
 	// FederationMultiRealmSecret - secret to store processed multirealm data
 	FederationMultiRealmSecret = "keystone-multirealm-federation-secret"
 	// FederationDefaultMountPath - if user doesn't specify otherwise, this location is used
-	FederationDefaultMountPath = "/etc/httpd/conf"
+	FederationDefaultMountPath = "/var/lib/config-data/default/multirealm-federation"
 )
 
 // KeystoneAPIPropagation is the  definition of the Horizon propagation service

--- a/pkg/keystone/deployment.go
+++ b/pkg/keystone/deployment.go
@@ -91,10 +91,21 @@ func Deployment(
 		volumeMounts = append(volumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
-	// add Federation volumes and volume mounts if needed
+	// add Federation volumes and volume mounts
 	if instance.Spec.FederatedRealmConfig != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "federation-realm-dir",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "federation-realm-dir",
+			MountPath: FederationDefaultMountPath,
+		})
+
 		volumes = append(volumes, getFederationVolumes(federationFilenames)...)
-		volumeMounts = append(volumeMounts, getFederationVolumeMounts(instance.Spec.FederationMountPath, federationFilenames)...)
+		volumeMounts = append(volumeMounts, getFederationVolumeMounts(FederationDefaultMountPath, federationFilenames)...)
 	}
 
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {

--- a/pkg/keystone/federation.go
+++ b/pkg/keystone/federation.go
@@ -16,9 +16,10 @@ limitations under the License.
 package keystone
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // getFederationVolumeMounts - get federation mountpoints

--- a/templates/keystoneapi/config/keystone-api-config.json
+++ b/templates/keystoneapi/config/keystone-api-config.json
@@ -65,7 +65,15 @@
             "owner": "keystone:apache",
             "perm": "0444",
             "optional": true
+        },
+        {
+            "source": "/var/lib/config-data/default/multirealm-federation/*",
+            "dest": "/etc/httpd/conf/",
+            "owner": "keystone:apache",
+            "perm": "0644",
+            "optional": true
         }
+
     ],
     "permissions": [
         {


### PR DESCRIPTION
The original multirealm‐federation patch #592  mounted files straight into /etc/ as root, making them unreadable by the apache and keystone users. This change instead mounts into /var/lib/... first, then copies the files into /etc/httpd/conf/ with the proper ownership.