### PR TITLE
Add Region parameter in the keystoneAPI status

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1638,6 +1638,9 @@ spec:
                 description: ReadyCount of keystone API instances
                 format: int32
                 type: integer
+              region:
+                description: Region - optional region name for the keystone service
+                type: string
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -281,6 +281,9 @@ type KeystoneAPIStatus struct {
 
 	// LastAppliedTopology - the last applied Topology
 	LastAppliedTopology *topologyv1.TopoRef `json:"lastAppliedTopology,omitempty"`
+
+	// Region - optional region name for the keystone service
+	Region string `json:"region,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -381,4 +384,9 @@ func (instance *KeystoneAPISpecCore) ValidateTopology(
 		instance.TopologyRef,
 		*basePath.Child("topologyRef"), namespace)...)
 	return allErrs
+}
+
+// GetRegion -
+func (instance *KeystoneAPI) GetRegion() string {
+	return instance.Status.Region
 }

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1638,6 +1638,9 @@ spec:
                 description: ReadyCount of keystone API instances
                 format: int32
                 type: integer
+              region:
+                description: Region - optional region name for the keystone service
+                type: string
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -1158,6 +1158,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	deploy := depl.GetDeployment()
 	if deploy.Generation == deploy.Status.ObservedGeneration {
 		instance.Status.ReadyCount = deploy.Status.ReadyReplicas
+		instance.Status.Region = instance.Spec.Region
 	}
 
 	// verify if network attachment matches expectations


### PR DESCRIPTION
There are services like `Glance` that need to configure parameters that are based on the `Keystone CR` we build. 
`oslo_limits` is an example of that, and we need to access the `Region` parameter that is defined in `keystone CR` spec.
It might be possible to rely on `gophercloud` and perform `os.GetRegion()`, but it seems too convoluted given that we regularly consume a `keystoneAPI` CR via `GetKeystoneAPI` from the service controllers and we this parameter is built based on the keystoneAPI Spec.
This patch mirrors the `Region` parameter in the `.Status` (according to the `ObservedGeneration` pattern), so we can access this field from a Service operator that needs it through the appropriate API function.