### PR TITLE
[golang] bump to golang 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.24-sdk-1.31

--- a/.github/workflows/build-keystone-operator.yaml
+++ b/.github/workflows/build-keystone-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: keystone
-      go_version: 1.21.x
+      go_version: 1.24.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.github/workflows/force-bump-pr-manual.yaml
+++ b/.github/workflows/force-bump-pr-manual.yaml
@@ -9,5 +9,6 @@ jobs:
     with:
       operator_name: keystone
       branch_name: ${{ github.ref_name }}
+      custom_image: quay.io/openstack-k8s-operators/openstack-k8s-operators-ci-build-tools:golang-1.24-sdk-1.31
     secrets:
       FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.github/workflows/force-bump-pr-scheduled.yaml
+++ b/.github/workflows/force-bump-pr-scheduled.yaml
@@ -10,5 +10,6 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/force-bump-branches.yaml@main
     with:
       operator_name: keystone
+      custom_image: quay.io/openstack-k8s-operators/openstack-k8s-operators-ci-build-tools:golang-1.24-sdk-1.31
     secrets:
       FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
@@ -5,17 +7,14 @@ linters:
     - errorlint
     - revive
     - ginkgolinter
-    - gofmt
     - govet
     - gosec
     - errname
     - err113
+
+formatters:
+  enable:
+    - gofmt
+
 run:
   timeout: 5m
-
-issues:
-  exclude-rules:
-  - path: tests
-    text: "G101: Potential hardcoded credentials"
-    linters:
-      - gosec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v2.4.0
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.24
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,10 @@ tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy
 	cd ./api && go mod tidy
 
+GOLANGCI_LINT_VERSION ?= v2.4.0
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix --verbose
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
@@ -207,7 +208,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.24.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/keystone-operator/api
 
-go 1.21
+go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/api/v1beta1/keystoneendpoint.go
+++ b/api/v1beta1/keystoneendpoint.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"time"
 
@@ -29,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"golang.org/x/exp/slices"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers implements the keystone-operator Kubernetes controllers.
 package controllers
 
 import (
@@ -86,7 +87,7 @@ func (r *KeystoneAPIReconciler) GetScheme() *runtime.Scheme {
 	return r.Scheme
 }
 
-// GetLog returns a logger object with a logging prefix of "controller.name" and additional controller context fields
+// GetLogger returns a logger object with a logging prefix of "controller.name" and additional controller context fields
 func (r *KeystoneAPIReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("KeystoneAPI")
 }
@@ -130,7 +131,7 @@ func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	Log := r.GetLogger(ctx)
 	// Fetch the KeystoneAPI instance
 	instance := &keystonev1.KeystoneAPI{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -363,7 +364,7 @@ func (r *KeystoneAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(ctx, keystoneAPIs, listOpts...); err != nil {
+		if err := r.List(ctx, keystoneAPIs, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve KeystoneAPI CRs %w")
 			return nil
 		}
@@ -1295,7 +1296,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(keystone.ServiceName), map[string]string{})
 
 	var tlsCfg *tls.Service
-	if instance.Spec.TLS.Ca.CaBundleSecretName != "" {
+	if instance.Spec.TLS.CaBundleSecretName != "" {
 		tlsCfg = &tls.Service{}
 	}
 
@@ -1383,7 +1384,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	// Marshal the templateParameters map to YAML
 	yamlData, err := yaml.Marshal(templateParameters)
 	if err != nil {
-		return fmt.Errorf("Error marshalling to YAML: %w", err)
+		return fmt.Errorf("error marshalling to YAML: %w", err)
 	}
 	customData[common.TemplateParameters] = string(yamlData)
 
@@ -1468,7 +1469,7 @@ func (r *KeystoneAPIReconciler) reconcileCloudConfig(
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	err = r.Client.Get(ctx, types.NamespacedName{Name: keystoneSecret.Name, Namespace: instance.Namespace}, keystoneSecret)
+	err = r.Get(ctx, types.NamespacedName{Name: keystoneSecret.Name, Namespace: instance.Namespace}, keystoneSecret)
 	if err != nil {
 		return err
 	}

--- a/controllers/keystoneendpoint_controller.go
+++ b/controllers/keystoneendpoint_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,7 +35,6 @@ import (
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	openstack "github.com/openstack-k8s-operators/lib-common/modules/openstack"
-	"golang.org/x/exp/slices"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 

--- a/controllers/keystoneendpoint_controller.go
+++ b/controllers/keystoneendpoint_controller.go
@@ -45,7 +45,7 @@ type KeystoneEndpointReconciler struct {
 	Scheme  *runtime.Scheme
 }
 
-// GetLog returns a logger object with a logging prefix of "controller.name" and additional controller context fields
+// GetLogger returns a logger object with a logging prefix of "controller.name" and additional controller context fields
 func (r *KeystoneEndpointReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("KeystoneEndpoint")
 }
@@ -64,7 +64,7 @@ func (r *KeystoneEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Fetch the KeystoneEndpoint instance
 	instance := &keystonev1.KeystoneEndpoint{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/controllers/keystoneservice_controller.go
+++ b/controllers/keystoneservice_controller.go
@@ -79,7 +79,7 @@ func (r *KeystoneServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Fetch the KeystoneService instance
 	instance := &keystonev1.KeystoneService{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/keystone-operator
 
-go 1.21
+go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250730071847-837b07f8d72f
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250811132527-8b60a24b4cd5
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.15
 	k8s.io/apimachinery v0.29.15
@@ -61,6 +60,7 @@ require (
 	github.com/rabbitmq/cluster-operator/v2 v2.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package main implements the keystone-operator controller manager.
 package main
 
 import (

--- a/pkg/keystone/bootstrap.go
+++ b/pkg/keystone/bootstrap.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package keystone contains keystone service bootstrap functionality.
 package keystone
 
 import (

--- a/pkg/keystone/cloudconfig.go
+++ b/pkg/keystone/cloudconfig.go
@@ -45,7 +45,7 @@ type OpenStackConfigSecret struct {
 	}
 }
 
-// generateCloudrc - generate file contents of a cloudrc file for the clients
+// GenerateCloudrc generates file contents of a cloudrc file for the clients
 // until there is parity with openstackclient.
 func GenerateCloudrc(secret *OpenStackConfigSecret, config *OpenStackConfig) string {
 	auth := config.Clouds.Default.Auth

--- a/pkg/keystone/const.go
+++ b/pkg/keystone/const.go
@@ -55,7 +55,7 @@ const (
 	FederationDefaultMountPath = "/var/lib/config-data/default/multirealm-federation"
 )
 
-// KeystoneAPIPropagation is the  definition of the Horizon propagation service
+// KeystonePropagation is the definition of the Keystone propagation service
 var KeystonePropagation = []storage.PropagationType{Keystone}
 
 // DBSyncPropagation keeps track of the DBSync Service Propagation Type

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -68,11 +68,11 @@ const (
 
 	DatabaseCRName = keystone_base.DatabaseCRName
 
-	PublicCertSecretName = "public-tls-certs"
+	PublicCertSecretName = "public-tls-certs" // #nosec G101
 
-	InternalCertSecretName = "internal-tls-certs"
+	InternalCertSecretName = "internal-tls-certs" // #nosec G101
 
-	CABundleSecretName = "combined-ca-bundle"
+	CABundleSecretName = "combined-ca-bundle" // #nosec G101
 
 	interval = time.Millisecond * 200
 )
@@ -193,7 +193,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-		conn.Close()
+		_ = conn.Close()
 		return nil
 	}).Should(Succeed())
 })


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v2.4.0
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.24-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.24
* delete current `go.work*` files
* init go work files `go work init`

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1082
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1567

Jira: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)