### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/keystoneapi_controller.go
+++ b/controllers/keystoneapi_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"time"
@@ -1323,9 +1324,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
 		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	transportURLSecret, _, err := oko_secret.GetSecret(ctx, h, instance.Status.TransportURLSecret, instance.Namespace)
 	if err != nil {
@@ -1335,7 +1334,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"MemcachedServers":         mc.GetMemcachedServerListString(),
 		"MemcachedServersWithInet": mc.GetMemcachedServerListWithInetString(),
 		"MemcachedTLS":             mc.GetMemcachedTLSSupport(),
@@ -1374,9 +1373,9 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 
 	// create httpd  vhost template parameters
 	customTemplates := map[string]string{}
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("%s-%s.%s.svc", instance.Name, endpt.String(), instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it bellow to true if enabled
 		if instance.Spec.TLS.API.Enabled(endpt) {
@@ -1439,7 +1438,7 @@ func (r *KeystoneAPIReconciler) reconcileCloudConfig(
 ) error {
 	// clouds.yaml
 	var openStackConfig keystone.OpenStackConfig
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(keystone.ServiceName), map[string]string{})
 
 	authURL, err := instance.GetEndpoint(endpoint.EndpointPublic)
@@ -1738,7 +1737,7 @@ func (r *KeystoneAPIReconciler) ensureFederationRealmConfig(
 	}
 	newSecretData["_filenames.json"] = string(filenamesJSON)
 
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(keystone.ServiceName), map[string]string{})
 	newSecret := []util.Template{
 		{

--- a/pkg/keystone/volumes.go
+++ b/pkg/keystone/volumes.go
@@ -35,7 +35,7 @@ func getVolumes(
 	fernetKeys := []corev1.KeyToPath{}
 	numberKeys := int(*instance.Spec.FernetMaxActiveKeys)
 
-	for i := 0; i < numberKeys; i++ {
+	for i := range numberKeys {
 		fernetKeys = append(
 			fernetKeys,
 			corev1.KeyToPath{

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -32,8 +32,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetKeystoneAPISpec(fernetMaxKeys int32) map[string]interface{} {
-	return map[string]interface{}{
+func GetKeystoneAPISpec(fernetMaxKeys int32) map[string]any {
+	return map[string]any{
 		"databaseInstance":    "openstack",
 		"replicas":            1,
 		"secret":              SecretName,
@@ -42,22 +42,22 @@ func GetKeystoneAPISpec(fernetMaxKeys int32) map[string]interface{} {
 	}
 }
 
-func GetDefaultKeystoneAPISpec() map[string]interface{} {
+func GetDefaultKeystoneAPISpec() map[string]any {
 	return GetKeystoneAPISpec(5)
 }
 
-func GetTLSKeystoneAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSKeystoneAPISpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"replicas":         1,
 		"secret":           SecretName,
 		"databaseAccount":  AccountName,
-		"tls": map[string]interface{}{
-			"api": map[string]interface{}{
-				"internal": map[string]interface{}{
+		"tls": map[string]any{
+			"api": map[string]any{
+				"internal": map[string]any{
 					"secretName": InternalCertSecretName,
 				},
-				"public": map[string]interface{}{
+				"public": map[string]any{
 					"secretName": PublicCertSecretName,
 				},
 			},
@@ -66,12 +66,12 @@ func GetTLSKeystoneAPISpec() map[string]interface{} {
 	}
 }
 
-func CreateKeystoneAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateKeystoneAPI(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "keystone.openstack.org/v1beta1",
 		"kind":       "KeystoneAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -114,7 +114,7 @@ func CreateKeystoneMessageBusSecret(namespace string, name string) *corev1.Secre
 	s := th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", name),
 		},
 	)
 	logger.Info("Secret created", "name", name)
@@ -129,16 +129,16 @@ func CreateKeystoneMessageBusSecret(namespace string, name string) *corev1.Secre
 // want to avoid by default
 // 2. Usually a topologySpreadConstraints is used to take care about
 // multi AZ, which is not applicable in this context
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"service":   keystone_base.ServiceName,
 						"component": label,
 					},
@@ -165,26 +165,26 @@ func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.Topol
 
 // GetExtraMounts - Utility function that simulates extraMounts pointing
 // to a  secret
-func GetExtraMounts(kemName string, kemPath string) []map[string]interface{} {
-	return []map[string]interface{}{
+func GetExtraMounts(kemName string, kemPath string) []map[string]any {
+	return []map[string]any{
 		{
 			"name":   kemName,
 			"region": "az0",
-			"extraVol": []map[string]interface{}{
+			"extraVol": []map[string]any{
 				{
 					"extraVolType": kemName,
 					"propagation": []string{
 						"Keystone",
 					},
-					"volumes": []map[string]interface{}{
+					"volumes": []map[string]any{
 						{
 							"name": kemName,
-							"secret": map[string]interface{}{
+							"secret": map[string]any{
 								"secretName": kemName,
 							},
 						},
 					},
-					"mounts": []map[string]interface{}{
+					"mounts": []map[string]any{
 						{
 							"name":      kemName,
 							"mountPath": kemPath,

--- a/tests/functional/keystoneapi_controller_test.go
+++ b/tests/functional/keystoneapi_controller_test.go
@@ -801,8 +801,8 @@ var _ = Describe("Keystone controller", func() {
 	When("A KeystoneAPI is created with service override", func() {
 		BeforeEach(func() {
 			spec := GetDefaultKeystoneAPISpec()
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"dnsmasq.network.openstack.org/hostname": "keystone-internal.openstack.svc",
@@ -815,12 +815,12 @@ var _ = Describe("Keystone controller", func() {
 						"service":  "keystone",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -889,12 +889,12 @@ var _ = Describe("Keystone controller", func() {
 	When("A KeystoneAPI is created with service override endpointURL set", func() {
 		BeforeEach(func() {
 			spec := GetDefaultKeystoneAPISpec()
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["public"] = map[string]any{
 				"endpointURL": "http://keystone-openstack.apps-crc.testing",
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -1173,12 +1173,12 @@ var _ = Describe("Keystone controller", func() {
 	When("A KeystoneAPI is created with TLS and service override endpointURL set", func() {
 		BeforeEach(func() {
 			spec := GetTLSKeystoneAPISpec()
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["public"] = map[string]any{
 				"endpointURL": "https://keystone-openstack.apps-crc.testing",
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -1287,7 +1287,7 @@ var _ = Describe("Keystone controller", func() {
 				}
 
 				g.Expect(numberFernetKeys).Should(BeNumerically("==", 3))
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					g.Expect(secret.Data["FernetKeys"+strconv.Itoa(i)]).NotTo(BeNil())
 				}
 			}, timeout, interval).Should(Succeed())
@@ -1340,7 +1340,7 @@ var _ = Describe("Keystone controller", func() {
 				}
 
 				g.Expect(numberFernetKeys).Should(BeNumerically("==", 100))
-				for i := 0; i < 100; i++ {
+				for i := range 100 {
 					g.Expect(secret.Data["FernetKeys"+strconv.Itoa(i)]).NotTo(BeNil())
 				}
 			}, timeout, interval).Should(Succeed())
@@ -1403,7 +1403,7 @@ var _ = Describe("Keystone controller", func() {
 				}
 
 				g.Expect(numberFernetKeys).Should(BeNumerically("==", 4))
-				for i := 0; i < 4; i++ {
+				for i := range 4 {
 					g.Expect(secret.Data["FernetKeys"+strconv.Itoa(i)]).NotTo(BeNil())
 				}
 			}, timeout, interval).Should(Succeed())
@@ -1466,7 +1466,7 @@ var _ = Describe("Keystone controller", func() {
 				}
 
 				g.Expect(numberFernetKeys).Should(BeNumerically("==", 6))
-				for i := 0; i < 6; i++ {
+				for i := range 6 {
 					g.Expect(secret.Data["FernetKeys"+strconv.Itoa(i)]).NotTo(BeNil())
 				}
 			}, timeout, interval).Should(Succeed())
@@ -1530,7 +1530,7 @@ var _ = Describe("Keystone controller", func() {
 				updatedSecret := th.GetSecret(types.NamespacedName{Namespace: keystoneAPIName.Namespace, Name: "keystone"})
 				g.Expect(updatedSecret).ToNot(BeNil())
 
-				for i := 0; i < 4; i++ {
+				for i := range 4 {
 
 					// old idx 0 > new 4
 					if i == 0 {
@@ -1575,7 +1575,7 @@ var _ = Describe("Keystone controller", func() {
 				infra.CreateTopology(t, topologySpec)
 			}
 			spec := GetDefaultKeystoneAPISpec()
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			DeferCleanup(
@@ -1698,7 +1698,7 @@ var _ = Describe("Keystone controller", func() {
 	When("A KeystoneAPI is created with nodeSelector", func() {
 		BeforeEach(func() {
 			spec := GetDefaultKeystoneAPISpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 			DeferCleanup(
@@ -1836,7 +1836,7 @@ OIDCRedirectURI "{{ .KeystoneEndpointPublic }}/v3/auth/OS-FEDERATION/websso/open
 			)
 
 			spec := GetDefaultKeystoneAPISpec()
-			spec["httpdCustomization"] = map[string]interface{}{
+			spec["httpdCustomization"] = map[string]any{
 				"customConfigSecret": customServiceConfigSecretName.Name,
 			}
 

--- a/tests/functional/keystoneapi_webhook_test.go
+++ b/tests/functional/keystoneapi_webhook_test.go
@@ -109,17 +109,17 @@ var _ = Describe("KeystoneAPI Webhook", func() {
 
 	It("rejects with wrong service override endpoint type", func() {
 		spec := GetDefaultKeystoneAPISpec()
-		spec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		spec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "keystone.openstack.org/v1beta1",
 			"kind":       "KeystoneAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      keystoneAPIName.Name,
 				"namespace": keystoneAPIName.Namespace,
 			},
@@ -198,14 +198,14 @@ var _ = Describe("KeystoneAPI Webhook", func() {
 	It("rejects a wrong TopologyRef on a different namespace", func() {
 		keystoneSpec := GetDefaultKeystoneAPISpec()
 		// Inject a topologyRef that points to a different namespace
-		keystoneSpec["topologyRef"] = map[string]interface{}{
+		keystoneSpec["topologyRef"] = map[string]any{
 			"name":      "foo",
 			"namespace": "bar",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "keystone.openstack.org/v1beta1",
 			"kind":       "KeystoneAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "keystoneapi",
 				"namespace": namespace,
 			},


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:
- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>