### PR TITLE
Add finalizer management and EDPM-aware cleanup for immutable AC secrets

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapplicationcredentials.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapplicationcredentials.yaml
@@ -209,6 +209,10 @@ spec:
                   for this ApplicationCredential.
                 format: int64
                 type: integer
+              previousSecretName:
+                description: PreviousSecretName - name of the previous AC secret.
+                  Only current and previous are protected by finalizer.
+                type: string
               rotationEligibleAt:
                 description: |-
                   RotationEligibleAt indicates when rotation becomes eligible (start of grace period window).

--- a/api/go.mod
+++ b/api/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260518125357-72bdd580c587
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20260506154724-30a976ba8ef0
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260506154724-30a976ba8ef0
-	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260506154724-30a976ba8ef0
+	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	k8s.io/api v0.31.14
 	k8s.io/apimachinery v0.31.14

--- a/api/go.sum
+++ b/api/go.sum
@@ -93,8 +93,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.2026050
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20260506154724-30a976ba8ef0/go.mod h1:7yqbVpg0k0vW+kZks+TMU/cd1ovoejyHfVPWcyGYLHI=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260506154724-30a976ba8ef0 h1:wuzSibIT9F/5RbMmxvBVFj6fy2vtKo58nibzmk5L4PM=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260506154724-30a976ba8ef0/go.mod h1:tft3oDiN+v6wX3ILPXGUM/gCLJz6QtrPN63hxpJ3E24=
-github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260506154724-30a976ba8ef0 h1:mG3QhS/QWv9Y/AkZZ5OzO6hu6+l5oDXnI/Q5ZUbj6Zs=
-github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260506154724-30a976ba8ef0/go.mod h1:ZYG9CQe7cOePOKQbenEZFA28kPdkUOe9QKbDRwGhEV0=
+github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587 h1:jpouKcgs2Kc5z2JHIpvsXMxEonfXLgzX3KswuBoeKQ0=
+github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587/go.mod h1:nLS2oK4pBo756JNN1cPgr44S0X9V11QScgVla89Ojok=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/api/v1beta1/keystoneapplicationcredential.go
+++ b/api/v1beta1/keystoneapplicationcredential.go
@@ -18,25 +18,21 @@ package v1beta1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/object"
 )
 
 // ApplicationCredentialData contains AC ID/Secret extracted from a Secret
-// Used by service operators to get AC data from the Secret
 type ApplicationCredentialData struct {
 	ID     string
 	Secret string
-}
-
-// GetACSecretName returns the standard AC Secret name for a service
-func GetACSecretName(serviceName string) string {
-	return fmt.Sprintf("ac-%s-secret", serviceName)
 }
 
 // GetACCRName returns the standard AC CR name for a service
@@ -51,37 +47,68 @@ const (
 	ACSecretSecretKey = "AC_SECRET"
 )
 
-var (
-	// ErrACIDMissing indicates AC_ID key missing or empty in the Secret
-	ErrACIDMissing = errors.New("applicationcredential secret missing AC_ID")
-	// ErrACSecretMissing indicates AC_SECRET key missing or empty in the Secret
-	ErrACSecretMissing = errors.New("applicationcredential secret missing AC_SECRET")
-)
-
-// GetApplicationCredentialFromSecret fetches and validates AC data from the Secret
-func GetApplicationCredentialFromSecret(
+// ManageACSecretFinalizer ensures consumerFinalizer is present on the AC secret
+// identified by newSecretName and absent from the one identified by
+// oldSecretName. It is a no-op when both names are equal.
+func ManageACSecretFinalizer(
 	ctx context.Context,
-	c client.Client,
+	h *helper.Helper,
 	namespace string,
-	serviceName string,
-) (*ApplicationCredentialData, error) {
-	secret := &corev1.Secret{}
-	key := types.NamespacedName{Namespace: namespace, Name: GetACSecretName(serviceName)}
-	if err := c.Get(ctx, key, secret); err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return nil, nil
+	newSecretName string,
+	oldSecretName string,
+	consumerFinalizer string,
+) error {
+	if newSecretName == oldSecretName {
+		return nil
+	}
+
+	var newObj, oldObj client.Object
+
+	if newSecretName != "" {
+		secret := &corev1.Secret{}
+		key := types.NamespacedName{Name: newSecretName, Namespace: namespace}
+		if err := h.GetClient().Get(ctx, key, secret); err != nil {
+			return fmt.Errorf("failed to get new AC secret %s: %w", newSecretName, err)
 		}
-		return nil, fmt.Errorf("get applicationcredential secret %s: %w", key, err)
+		newObj = secret
 	}
 
-	acID, okID := secret.Data[ACIDSecretKey]
-	if !okID || len(acID) == 0 {
-		return nil, fmt.Errorf("%w: %s", ErrACIDMissing, key.String())
-	}
-	acSecret, okSecret := secret.Data[ACSecretSecretKey]
-	if !okSecret || len(acSecret) == 0 {
-		return nil, fmt.Errorf("%w: %s", ErrACSecretMissing, key.String())
+	if oldSecretName != "" {
+		secret := &corev1.Secret{}
+		key := types.NamespacedName{Name: oldSecretName, Namespace: namespace}
+		if err := h.GetClient().Get(ctx, key, secret); err != nil {
+			if !k8s_errors.IsNotFound(err) {
+				return fmt.Errorf("failed to get old AC secret %s: %w", oldSecretName, err)
+			}
+		} else {
+			oldObj = secret
+		}
 	}
 
-	return &ApplicationCredentialData{ID: string(acID), Secret: string(acSecret)}, nil
+	return object.ManageConsumerFinalizer(ctx, h, newObj, oldObj, consumerFinalizer)
+}
+
+// RemoveACSecretConsumerFinalizer removes consumerFinalizer from the AC secret
+// identified by secretName. It is a no-op when secretName is empty or the
+// secret no longer exists.
+func RemoveACSecretConsumerFinalizer(
+	ctx context.Context,
+	h *helper.Helper,
+	namespace string,
+	secretName string,
+	consumerFinalizer string,
+) error {
+	if secretName == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: secretName, Namespace: namespace}
+	if err := h.GetClient().Get(ctx, key, secret); err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return object.RemoveConsumerFinalizer(ctx, h, secret, consumerFinalizer)
 }

--- a/api/v1beta1/keystoneapplicationcredential.go
+++ b/api/v1beta1/keystoneapplicationcredential.go
@@ -18,25 +18,22 @@ package v1beta1
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/object"
 )
 
 // ApplicationCredentialData contains AC ID/Secret extracted from a Secret
-// Used by service operators to get AC data from the Secret
 type ApplicationCredentialData struct {
 	ID     string
 	Secret string
-}
-
-// GetACSecretName returns the standard AC Secret name for a service
-func GetACSecretName(serviceName string) string {
-	return fmt.Sprintf("ac-%s-secret", serviceName)
 }
 
 // GetACCRName returns the standard AC CR name for a service
@@ -44,44 +41,94 @@ func GetACCRName(serviceName string) string {
 	return fmt.Sprintf("ac-%s", serviceName)
 }
 
+// GetServiceNameFromACCR extracts the service name from an AC CR name
+// by stripping the "ac-" prefix. This is the inverse of GetACCRName.
+func GetServiceNameFromACCR(acName string) string {
+	return strings.TrimPrefix(acName, "ac-")
+}
+
 const (
 	// ACIDSecretKey is the key for the ApplicationCredential ID in the Secret
 	ACIDSecretKey = "AC_ID"
 	// ACSecretSecretKey is the key for the ApplicationCredential secret in the Secret
 	ACSecretSecretKey = "AC_SECRET"
+
+	// EDPMServiceAnnotation marks whether an AC CR's credentials are deployed
+	// to EDPM nodes. The AC controller gates cleanup and deletion on NodeSet
+	// secret hash sync unless this annotation is explicitly set to "false".
+	// Missing annotation defaults to EDPM service (as fail safe).
+	EDPMServiceAnnotation = "keystone.openstack.org/edpm-service" // #nosec G101
 )
 
-var (
-	// ErrACIDMissing indicates AC_ID key missing or empty in the Secret
-	ErrACIDMissing = errors.New("applicationcredential secret missing AC_ID")
-	// ErrACSecretMissing indicates AC_SECRET key missing or empty in the Secret
-	ErrACSecretMissing = errors.New("applicationcredential secret missing AC_SECRET")
-)
+// IsEDPMService returns true unless the annotation is explicitly set to "false".
+// Missing annotation defaults to true as a safety mechanism: if the annotation
+// is accidentally removed, the AC is still protected by EDPM hash sync checks.
+func (ac *KeystoneApplicationCredential) IsEDPMService() bool {
+	return ac.GetAnnotations()[EDPMServiceAnnotation] != "false"
+}
 
-// GetApplicationCredentialFromSecret fetches and validates AC data from the Secret
-func GetApplicationCredentialFromSecret(
+// ManageACSecretFinalizer ensures consumerFinalizer is present on the AC secret
+// identified by newSecretName and absent from the one identified by
+// oldSecretName. It is a no-op when both names are equal.
+func ManageACSecretFinalizer(
 	ctx context.Context,
-	c client.Client,
+	h *helper.Helper,
 	namespace string,
-	serviceName string,
-) (*ApplicationCredentialData, error) {
-	secret := &corev1.Secret{}
-	key := types.NamespacedName{Namespace: namespace, Name: GetACSecretName(serviceName)}
-	if err := c.Get(ctx, key, secret); err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return nil, nil
+	newSecretName string,
+	oldSecretName string,
+	consumerFinalizer string,
+) error {
+	if newSecretName == oldSecretName {
+		return nil
+	}
+
+	var newObj, oldObj client.Object
+
+	if newSecretName != "" {
+		secret := &corev1.Secret{}
+		key := types.NamespacedName{Name: newSecretName, Namespace: namespace}
+		if err := h.GetClient().Get(ctx, key, secret); err != nil {
+			return fmt.Errorf("failed to get new AC secret %s: %w", newSecretName, err)
 		}
-		return nil, fmt.Errorf("get applicationcredential secret %s: %w", key, err)
+		newObj = secret
 	}
 
-	acID, okID := secret.Data[ACIDSecretKey]
-	if !okID || len(acID) == 0 {
-		return nil, fmt.Errorf("%w: %s", ErrACIDMissing, key.String())
-	}
-	acSecret, okSecret := secret.Data[ACSecretSecretKey]
-	if !okSecret || len(acSecret) == 0 {
-		return nil, fmt.Errorf("%w: %s", ErrACSecretMissing, key.String())
+	if oldSecretName != "" {
+		secret := &corev1.Secret{}
+		key := types.NamespacedName{Name: oldSecretName, Namespace: namespace}
+		if err := h.GetClient().Get(ctx, key, secret); err != nil {
+			if !k8s_errors.IsNotFound(err) {
+				return fmt.Errorf("failed to get old AC secret %s: %w", oldSecretName, err)
+			}
+		} else {
+			oldObj = secret
+		}
 	}
 
-	return &ApplicationCredentialData{ID: string(acID), Secret: string(acSecret)}, nil
+	return object.ManageConsumerFinalizer(ctx, h, newObj, oldObj, consumerFinalizer)
+}
+
+// RemoveACSecretConsumerFinalizer removes consumerFinalizer from the AC secret
+// identified by secretName. It is a no-op when secretName is empty or the
+// secret no longer exists.
+func RemoveACSecretConsumerFinalizer(
+	ctx context.Context,
+	h *helper.Helper,
+	namespace string,
+	secretName string,
+	consumerFinalizer string,
+) error {
+	if secretName == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: secretName, Namespace: namespace}
+	if err := h.GetClient().Get(ctx, key, secret); err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return object.RemoveConsumerFinalizer(ctx, h, secret, consumerFinalizer)
 }

--- a/api/v1beta1/keystoneapplicationcredential_types.go
+++ b/api/v1beta1/keystoneapplicationcredential_types.go
@@ -91,6 +91,9 @@ type KeystoneApplicationCredentialStatus struct {
 	// SecretName - name of the k8s Secret storing the ApplicationCredential secret
 	SecretName string `json:"secretName,omitempty"`
 
+	// PreviousSecretName - name of the previous AC secret. Only current and previous are protected by finalizer.
+	PreviousSecretName string `json:"previousSecretName,omitempty"`
+
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty"`
 

--- a/config/crd/bases/keystone.openstack.org_keystoneapplicationcredentials.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapplicationcredentials.yaml
@@ -209,6 +209,10 @@ spec:
                   for this ApplicationCredential.
                 format: int64
                 type: integer
+              previousSecretName:
+                description: PreviousSecretName - name of the previous AC secret.
+                  Only current and previous are protected by finalizer.
+                type: string
               rotationEligibleAt:
                 description: |-
                   RotationEligibleAt indicates when rotation becomes eligible (start of grace period window).

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,6 +74,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - dataplane.openstack.org
+  resources:
+  - openstackdataplanenodesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - k8s.cni.cncf.io
   resources:
   - network-attachment-definitions

--- a/docs/applicationcredentials.md
+++ b/docs/applicationcredentials.md
@@ -53,7 +53,8 @@ status:
   # ACID - the ID in Keystone for this ApplicationCredential
   ACID: "7b23dbac20bc4f048f937415c84bb329"
   # SecretName - name of the k8s Secret storing the ApplicationCredential secret
-  secretName: "ac-barbican-secret"
+  # Format: ac-<service>-<first5ofACID>-secret
+  secretName: "ac-barbican-7b23d-secret"
   # CreatedAt - timestamp of creation
   createdAt: "2025-05-29T09:02:28Z"
   # ExpiresAt - time of validity expiration
@@ -120,17 +121,29 @@ the AC controller:
    - Includes access rules if specified in the CR
 
 8. Store Secret
-   - Creates a k8s `Secret` named `ac-barbican-secret`
+   - Creates a new **immutable** k8s `Secret` with a unique name: `ac-<service>-<first5ofACID>-secret`
+   - The name includes the first 5 characters of the Keystone AC ID for uniqueness
    - Adds `openstack.org/ac-secret-protection` finalizer to the Secret
+   - Sets owner reference to the AC CR (for garbage collection on CR deletion)
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ac-barbican-secret
+  name: ac-barbican-7b23d-secret
   namespace: openstack
+  labels:
+    application-credentials: "true"
+    application-credential-service: barbican
   finalizers:
     - openstack.org/ac-secret-protection
+  ownerReferences:
+    - apiVersion: keystone.openstack.org/v1beta1
+      kind: KeystoneApplicationCredential
+      name: ac-barbican
+      controller: true
+      blockOwnerDeletion: true
+immutable: true
 data:
   AC_ID:     <base64-of-AC-ID>
   AC_SECRET: <base64-of-AC-secret>
@@ -138,13 +151,8 @@ data:
 
 9. Update CR status
    - Sets `.status.ACID`, `.status.secretName`, `.status.createdAt`, `.status.expiresAt`, `.status.rotationEligibleAt`
-   - Sets `.status.lastRotated` (only during rotation, not initial creation)
+   - Sets `.status.lastRotated` and emits `ApplicationCredentialRotated` event (only during rotation, not initial creation)
    - Marks AC CR ready
-   - Emits an event for rotation to notify EDPM nodes
-
-10. Requeue for Next Check
-    - Calculates next reconcile at `expiresAt - gracePeriod`
-    - If already in grace window, requeues immediately, otherwise requeues after 24 h
 
 AC in Keystone side:
 ```
@@ -174,15 +182,20 @@ When the next reconcile hits the grace window (`now ≥ expiresAt - gracePeriodD
   - Generates a new Keystone AC with a fresh 5-char suffix
   - Uses the same roles, unrestricted flag, access rules, and expirationDays
   - Does _not_ revoke the old AC, the old credential naturally expires
-- Store Updated Secret
-  - Overwrites the existing `ac-barbican-secret` with the new `AC_ID` and `AC_SECRET`
+- Create New Immutable Secret
+  - Creates a **new** immutable Secret with a unique name (e.g. `ac-barbican-d38dc-secret`)
+  - The previous Secret (e.g. `ac-barbican-7b23d-secret`) is **retained** — it is not deleted
+  - Both secrets are owned by the AC CR and will be garbage-collected when the CR is deleted
 - Update Status
+  - Sets `.status.secretName` to the new Secret name
   - Replaces `.status.ACID`, `.status.createdAt`, `.status.expiresAt`, and `.status.rotationEligibleAt` with the new values
   - Sets `.status.lastRotated` to current timestamp
   - Re-marks AC CR ready
-  - Emits an event to notify EDPM nodes about the rotation
-- Requeue
-  - Schedules the next check at `(newExpiresAt - gracePeriodDays)`
+  - Emits `ApplicationCredentialRotated` event for EDPM visibility
+- Propagation
+  - The openstack-operator `Owns` the AC CR, so the status change triggers re-reconciliation
+  - It reads the new `.status.secretName` and updates the service CR's `ApplicationCredentialSecret`
+  - The service operator detects the spec change and reads credentials from the new Secret
 
 ## Manual Rotation
 
@@ -203,8 +216,8 @@ This triggers seamless rotation with one pod restart and no authentication fallb
 ApplicationCredentials in Keystone are **not automatically deleted** by the controller. This design decision prevents disrupting running services, especially EDPM nodes that actively use these credentials.
 
 **Cleanup behavior:**
-- **During rotation:** The old AC remains in Keystone and expires naturally based on its `expiresAt` timestamp. The new AC is created with fresh credentials.
-- **When AC CR is deleted:** The ApplicationCredential remains in Keystone and continues to be valid until natural expiration.
+- **During rotation:** The old AC remains in Keystone and expires naturally based on its `expiresAt` timestamp. The old K8s Secret is also retained (immutable). A new AC and a new immutable Secret are created.
+- **When AC CR is deleted:** The controller removes the `openstack.org/ac-secret-protection` finalizer from **all** AC Secrets for the service (found by label), allowing owner-reference garbage collection to delete them. The ApplicationCredential in Keystone remains valid until natural expiration.
 - **Manual cleanup:** If immediate cleanup is required, operators can manually delete the AC from Keystone:
 
 ```bash
@@ -213,29 +226,22 @@ openstack application credential delete <ac-id>
 
 This approach ensures that deleting the AC CR (intentionally or accidentally) does not cause immediate authentication failures across the control plane and EDPM deployments.
 
-## Client-Side Helper Functions
+## Exported API Helpers
 
-Service operators can use these helper functions to consume ApplicationCredential data:
+The `keystone-operator/api/v1beta1` package exports the following helpers for use by other operators:
 
 ```go
 import keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 
-// Get standard AC Secret name for a service
-secretName := keystonev1.GetACSecretName("barbican") // Returns "ac-barbican-secret"
-
 // Get standard AC CR name for a service
 crName := keystonev1.GetACCRName("barbican") // Returns "ac-barbican"
 
-// Fetch AC data directly from the Secret
-acData, err := keystonev1.GetApplicationCredentialFromSecret(
-    ctx, client, namespace, serviceName)
-if err != nil {
-    // Handle error
-}
-if acData != nil {
-    // Use acData.ID and acData.Secret
-}
+// Secret data keys
+keystonev1.ACIDSecretKey     // "AC_ID"
+keystonev1.ACSecretSecretKey // "AC_SECRET"
 ```
+
+Service operators read AC data directly from the Secret referenced by the service CR's `ApplicationCredentialSecret` field, using `ACIDSecretKey` and `ACSecretSecretKey` as the data keys.
 
 ## Validation Rules
 

--- a/docs/applicationcredentials.md
+++ b/docs/applicationcredentials.md
@@ -53,13 +53,16 @@ status:
   # ACID - the ID in Keystone for this ApplicationCredential
   ACID: "7b23dbac20bc4f048f937415c84bb329"
   # SecretName - name of the k8s Secret storing the ApplicationCredential secret
-  secretName: "ac-barbican-secret"
+  # Format: ac-<service>-<first5ofACID>-secret
+  secretName: "ac-barbican-7b23d-secret"
   # CreatedAt - timestamp of creation
   createdAt: "2025-05-29T09:02:28Z"
   # ExpiresAt - time of validity expiration
   expiresAt: "2026-05-29T09:02:28Z"
   # RotationEligibleAt - when rotation becomes eligible (ExpiresAt - GracePeriodDays)
   rotationEligibleAt: "2025-11-29T09:02:28Z"
+  # PreviousSecretName - the Secret from the prior rotation (retained for EDPM/consumer transition)
+  previousSecretName: "ac-barbican-a1b2c-secret"
   # LastRotated - timestamp when credentials were last rotated (only set after first rotation)
   lastRotated: "2025-05-29T09:02:28Z"
   # Conditions
@@ -120,17 +123,29 @@ the AC controller:
    - Includes access rules if specified in the CR
 
 8. Store Secret
-   - Creates a k8s `Secret` named `ac-barbican-secret`
+   - Creates a new **immutable** k8s `Secret` with a unique name: `ac-<service>-<first5ofACID>-secret`
+   - The name includes the first 5 characters of the Keystone AC ID for uniqueness
    - Adds `openstack.org/ac-secret-protection` finalizer to the Secret
+   - Sets owner reference to the AC CR (for garbage collection on CR deletion)
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ac-barbican-secret
+  name: ac-barbican-7b23d-secret
   namespace: openstack
+  labels:
+    application-credentials: "true"
+    application-credential-service: barbican
   finalizers:
     - openstack.org/ac-secret-protection
+  ownerReferences:
+    - apiVersion: keystone.openstack.org/v1beta1
+      kind: KeystoneApplicationCredential
+      name: ac-barbican
+      controller: true
+      blockOwnerDeletion: true
+immutable: true
 data:
   AC_ID:     <base64-of-AC-ID>
   AC_SECRET: <base64-of-AC-secret>
@@ -138,13 +153,8 @@ data:
 
 9. Update CR status
    - Sets `.status.ACID`, `.status.secretName`, `.status.createdAt`, `.status.expiresAt`, `.status.rotationEligibleAt`
-   - Sets `.status.lastRotated` (only during rotation, not initial creation)
+   - Sets `.status.lastRotated` and emits `ApplicationCredentialRotated` event (only during rotation, not initial creation)
    - Marks AC CR ready
-   - Emits an event for rotation to notify EDPM nodes
-
-10. Requeue for Next Check
-    - Calculates next reconcile at `expiresAt - gracePeriod`
-    - If already in grace window, requeues immediately, otherwise requeues after 24 h
 
 AC in Keystone side:
 ```
@@ -173,16 +183,22 @@ When the next reconcile hits the grace window (`now ≥ expiresAt - gracePeriodD
 - Create New AC
   - Generates a new Keystone AC with a fresh 5-char suffix
   - Uses the same roles, unrestricted flag, access rules, and expirationDays
-  - Does _not_ revoke the old AC, the old credential naturally expires
-- Store Updated Secret
-  - Overwrites the existing `ac-barbican-secret` with the new `AC_ID` and `AC_SECRET`
+- Create New Immutable Secret
+  - Creates a **new** immutable Secret with a unique name (e.g. `ac-barbican-d38dc-secret`)
+  - The previous Secret (e.g. `ac-barbican-7b23d-secret`) is retained as `previousSecretName`
+- Cleanup Old Secrets
+  - Secrets older than `previousSecretName` that have no consumer finalizer are revoked in Keystone and deleted
+  - If EDPM NodeSet hashes are out of sync, cleanup is deferred until the next EDPM deploy (see [EDPM Awareness](#edpm-awareness))
 - Update Status
+  - Sets `.status.secretName` to the new Secret name
   - Replaces `.status.ACID`, `.status.createdAt`, `.status.expiresAt`, and `.status.rotationEligibleAt` with the new values
   - Sets `.status.lastRotated` to current timestamp
   - Re-marks AC CR ready
-  - Emits an event to notify EDPM nodes about the rotation
-- Requeue
-  - Schedules the next check at `(newExpiresAt - gracePeriodDays)`
+  - Emits `ApplicationCredentialRotated` event with expiration and grace period details
+- Propagation
+  - The openstack-operator `Owns` the AC CR, so the status change triggers re-reconciliation
+  - It reads the new `.status.secretName` and updates the service CR's `ApplicationCredentialSecret`
+  - The service operator detects the spec change and reads credentials from the new Secret
 
 ## Manual Rotation
 
@@ -200,42 +216,49 @@ This triggers seamless rotation with one pod restart and no authentication fallb
 
 ## ApplicationCredential Lifecycle and Cleanup
 
-ApplicationCredentials in Keystone are **not automatically deleted** by the controller. This design decision prevents disrupting running services, especially EDPM nodes that actively use these credentials.
+After rotation, the controller actively cleans up unused old secrets. The `cleanupUnusedRotatedSecrets` function finds rotated secrets that are neither the current nor previous secret and have no service consumer finalizer, then revokes the AC in Keystone and deletes the K8s Secret.
 
 **Cleanup behavior:**
-- **During rotation:** The old AC remains in Keystone and expires naturally based on its `expiresAt` timestamp. The new AC is created with fresh credentials.
-- **When AC CR is deleted:** The ApplicationCredential remains in Keystone and continues to be valid until natural expiration.
+- **During rotation:** A new AC and immutable Secret are created. The current secret becomes tracked as `previousSecretName`. Older secrets are revoked in Keystone and deleted from Kubernetes.
+- **Consumer finalizer protection:** Service operators place a finalizer (e.g. `openstack.org/barbican-ac-consumer`) on the AC secret they are actively using. Secrets with a consumer finalizer are never deleted, regardless of rotation state.
+- **When AC CR is deleted:** The controller first checks that all EDPM NodeSet hashes are in sync (see [EDPM Awareness](#edpm-awareness)); if not, deletion is deferred. Once in sync, it revokes ACs in Keystone (best-effort) and removes the `openstack.org/ac-secret-protection` finalizer from **all** AC Secrets for the service (found by label), allowing owner-reference garbage collection to delete them.
 - **Manual cleanup:** If immediate cleanup is required, operators can manually delete the AC from Keystone:
 
 ```bash
 openstack application credential delete <ac-id>
 ```
 
-This approach ensures that deleting the AC CR (intentionally or accidentally) does not cause immediate authentication failures across the control plane and EDPM deployments.
+## EDPM Awareness
 
-## Client-Side Helper Functions
+Nova and ceilometer services render AC secret data into config secrets deployed to EDPM dataplane nodes via ansible. After an AC rotation on the controlplane, EDPM nodes still use the old credentials until the next EDPM deploy. The controller prevents premature revocation of these credentials.
 
-Service operators can use these helper functions to consume ApplicationCredential data:
+**Opt-out via annotation:**
+The `openstack-operator` sets the `keystone.openstack.org/edpm-service` annotation on every AC CR it manages. Services whose credentials are rendered to EDPM nodes (currently nova and ceilometer) are annotated with `"true"`. Controlplane-only services (barbican, heat, etc.) are annotated with `"false"` and skip the NodeSet hash sync check. If the annotation is missing (e.g., accidentally removed or the AC CR was created outside of `openstack-operator`), the controller defaults to EDPM-aware as a fail-safe.
+
+**How it works:**
+- Before cleaning up unused rotated secrets **or proceeding with AC CR deletion**, the controller checks `instance.IsEDPMService()`. If `true`, it calls `edpm.AreSecretHashesInSync()` from `lib-common/modules/edpm/unstructured`. This compares each `OpenStackDataPlaneNodeSet`'s `status.secretHashes` against the live secret hashes in the namespace.
+- If any NodeSet has stale hashes (config changed but EDPM not yet redeployed), AC secret cleanup and AC CR deletion are deferred for that EDPM-aware AC CR.
+- The controller watches `OpenStackDataPlaneNodeSet` resources (via unstructured access, no typed import) and re-evaluates eligibility when a NodeSet status changes — typically after an EDPM deploy updates `status.secretHashes`.
+- If the NodeSet CRD is not installed or no NodeSets exist, cleanup and deletion proceed normally.
+
+This approach is aligned with the RabbitMQ user deletion design in infra-operator, which uses the same `lib-common/modules/edpm/unstructured` module to gate resource cleanup on NodeSet deployment status.
+
+## Exported API Helpers
+
+The `keystone-operator/api/v1beta1` package exports the following helpers for use by other operators:
 
 ```go
 import keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 
-// Get standard AC Secret name for a service
-secretName := keystonev1.GetACSecretName("barbican") // Returns "ac-barbican-secret"
-
 // Get standard AC CR name for a service
 crName := keystonev1.GetACCRName("barbican") // Returns "ac-barbican"
 
-// Fetch AC data directly from the Secret
-acData, err := keystonev1.GetApplicationCredentialFromSecret(
-    ctx, client, namespace, serviceName)
-if err != nil {
-    // Handle error
-}
-if acData != nil {
-    // Use acData.ID and acData.Secret
-}
+// Secret data keys
+keystonev1.ACIDSecretKey     // "AC_ID"
+keystonev1.ACSecretSecretKey // "AC_SECRET"
 ```
+
+Service operators read AC data directly from the Secret referenced by the service CR's `ApplicationCredentialSecret` field, using `ACIDSecretKey` and `ACSecretSecretKey` as the data keys.
 
 ## Validation Rules
 

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,10 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260508091801-73f228e6af31
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240213125925-e40975f3db7e
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260518125357-72bdd580c587
+	github.com/openstack-k8s-operators/lib-common/modules/edpm v0.0.0-20260518125357-72bdd580c587
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20260506154724-30a976ba8ef0
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260506154724-30a976ba8ef0
-	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260506154724-30a976ba8ef0
+	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260503164939-40728ae44d65
 	go.uber.org/zap v1.28.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -100,6 +101,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/grpc v1.71.1 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,12 +124,14 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260508091801-7
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260508091801-73f228e6af31/go.mod h1:/S2AN21zV70V1XuL0Of2dCjYWNkKwQSyNI8l/iQVrMs=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260518125357-72bdd580c587 h1:p03uEXoSreyu7LpFmb9YyYM8tEx2D2+7qqhLXNWHTq0=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260518125357-72bdd580c587/go.mod h1:JC04T5G4E/he5ukonV1oCqa0QzFkLv761VbLruVghJM=
+github.com/openstack-k8s-operators/lib-common/modules/edpm v0.0.0-20260518125357-72bdd580c587 h1:JSp8IpCmeK3fydTrlQEEhN4b91aepN86NI2h07XaV6o=
+github.com/openstack-k8s-operators/lib-common/modules/edpm v0.0.0-20260518125357-72bdd580c587/go.mod h1:xsKeDFU3/xEObaVDqd6XEYV3MzvFswbWMlnr2Z3q3ZI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20260506154724-30a976ba8ef0 h1:kMie+G0aHlGwDHjimjj8AUxTl2R7LGfai/8pev2T+TY=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20260506154724-30a976ba8ef0/go.mod h1:7yqbVpg0k0vW+kZks+TMU/cd1ovoejyHfVPWcyGYLHI=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260506154724-30a976ba8ef0 h1:wuzSibIT9F/5RbMmxvBVFj6fy2vtKo58nibzmk5L4PM=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260506154724-30a976ba8ef0/go.mod h1:tft3oDiN+v6wX3ILPXGUM/gCLJz6QtrPN63hxpJ3E24=
-github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260506154724-30a976ba8ef0 h1:mG3QhS/QWv9Y/AkZZ5OzO6hu6+l5oDXnI/Q5ZUbj6Zs=
-github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260506154724-30a976ba8ef0/go.mod h1:ZYG9CQe7cOePOKQbenEZFA28kPdkUOe9QKbDRwGhEV0=
+github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587 h1:jpouKcgs2Kc5z2JHIpvsXMxEonfXLgzX3KswuBoeKQ0=
+github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587/go.mod h1:nLS2oK4pBo756JNN1cPgr44S0X9V11QScgVla89Ojok=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260503164939-40728ae44d65 h1:MNjmU326MKwYU6xT6AL2aKbr/0ids87wP5B+s5CL2O0=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260503164939-40728ae44d65/go.mod h1:I2LO+wGIzbirVczQ9qo/49y2F5Zo/MEg/pabkXOrY2M=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/controller/keystoneapplicationcredential_controller.go
+++ b/internal/controller/keystoneapplicationcredential_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -29,6 +31,7 @@ import (
 	"github.com/openstack-k8s-operators/keystone-operator/internal/keystone"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,13 +42,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const acSecretFinalizer = "openstack.org/ac-secret-protection" // #nosec G101
 const finalizer = "openstack.org/applicationcredential"        // #nosec G101
+
+var errACIDMismatch = fmt.Errorf("AC secret already exists with a different ACID")
 
 // ApplicationCredentialReconciler reconciles an ApplicationCredential object
 type ApplicationCredentialReconciler struct {
@@ -59,6 +67,7 @@ type ApplicationCredentialReconciler struct {
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapplicationcredentials,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapplicationcredentials/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapplicationcredentials/finalizers,verbs=update;patch
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=delete
 //+kubebuilder:rbac:groups=core,resources=secrets/finalizers,verbs=get;list;create;update;delete;patch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
@@ -140,7 +149,7 @@ func (r *ApplicationCredentialReconciler) Reconcile(ctx context.Context, req ctr
 			// any actual ApplicationCredential, just redirect execution to the "reconcileDelete()"
 			// logic to avoid potentially hanging on waiting for a KeystoneAPI to appear
 			if !instance.DeletionTimestamp.IsZero() {
-				return r.reconcileDelete(ctx, instance, helperObj)
+				return r.reconcileDelete(ctx, instance, helperObj, nil)
 			}
 
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -162,10 +171,11 @@ func (r *ApplicationCredentialReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	// If this KeystoneApplicationCredential CR is being deleted, perform delete cleanup without waiting for KeystoneAPI readiness
-	// NOTE: We don't talk to KeystoneAPI during delete, so KeystoneAPI readiness/deletion check is not needed here
+	// Deletion skips the KeystoneAPI IsReady() check below, so the AC CR is not blocked on readiness
+	// reconcileDelete receives keystoneAPI to attempt best-effort Keystone AC revocation
+	// If Keystone is unreachable (e.g. full teardown), revocation is skipped and finalizers are still removed so the CR deletion is never blocked
 	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance, helperObj)
+		return r.reconcileDelete(ctx, instance, helperObj, keystoneAPI)
 	}
 
 	if !keystoneAPI.IsReady() {
@@ -203,7 +213,8 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 		return ctrl.Result{}, err
 	}
 
-	// Inspect current Secret status
+	// If the current secret was deleted (e.g. manual cleanup, accidental removal),
+	// fall through to rotation so the controller self-heals.
 	if instance.Status.SecretName != "" {
 		secret := &corev1.Secret{}
 		key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.SecretName}
@@ -283,9 +294,23 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 			return ctrl.Result{}, err
 		}
 
-		// Store it in a Secret (create or update)
-		secretName := fmt.Sprintf("%s-secret", instance.Name)
-		if err := r.storeACSecret(ctx, helperObj, instance, secretName, newID, newSecret); err != nil {
+		// Create a new immutable Secret with a unique name
+		secretName, err := r.createImmutableACSecret(ctx, helperObj, instance, newID, newSecret)
+		if err != nil {
+			// The Keystone AC was already created above but its secret cannot be stored.
+			// Revoke it so it doesn't become a permanently orphaned credential in Keystone.
+			if revokeErr := revokeKeystoneAC(ctx, userOS.GetOSClient(), userID, newID); revokeErr != nil {
+				logger.Error(revokeErr, "Failed to revoke orphaned Keystone AC after secret creation failure", "ACID", newID)
+			} else {
+				logger.Info("Revoked orphaned Keystone AC after secret creation failure", "ACID", newID)
+			}
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				keystonev1.KeystoneApplicationCredentialReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				keystonev1.KeystoneApplicationCredentialReadyErrorMessage,
+				fmt.Sprintf("Failed to create AC secret: %s", err.Error()),
+			))
 			return ctrl.Result{}, err
 		}
 
@@ -295,7 +320,10 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 			previousExpiresAt = instance.Status.ExpiresAt.Format(time.RFC3339)
 		}
 
-		// Update status
+		// Update status, capture previous secret before rotation for rollback tracking
+		if isRotation && instance.Status.SecretName != "" {
+			instance.Status.PreviousSecretName = instance.Status.SecretName
+		}
 		instance.Status.ACID = newID
 		instance.Status.SecretName = secretName
 		instance.Status.CreatedAt = &metav1.Time{Time: time.Now().UTC()}
@@ -335,7 +363,23 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 		}
 
 		logger.Info("ApplicationCredential ready", "secret", secretName, "ACID", newID, "expiresAt", expiresAt)
-		return ctrl.Result{}, nil
+
+		// Return early after creation/rotation so the defer patches the status.
+		// The status patch triggers a re-reconcile via the For() watch, at which
+		// point the cache is fresh and cleanup of unused rotated secrets can run.
+		// RequeueAfter is a safety net in case the watch event is delayed.
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+	}
+
+	// Migrate old mutable secrets: add the application-credential-service label
+	// if missing, so they become visible to label-based cleanup and deletion queries
+	serviceName := strings.TrimPrefix(instance.Name, "ac-")
+	for _, sn := range []string{instance.Status.SecretName, instance.Status.PreviousSecretName} {
+		if sn != "" {
+			if err := r.ensureServiceLabel(ctx, helperObj, sn, instance.Namespace, serviceName); err != nil {
+				logger.Info("Could not ensure service label on secret", "secret", sn, "error", err)
+			}
+		}
 	}
 
 	// ApplicationCredential already exists and is valid
@@ -346,42 +390,246 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 		instance.Status.RotationEligibleAt = &metav1.Time{Time: rotationEligibleAt}
 	}
 
+	// Unused rotated AC secrets (not current/previous, no consumer finalizer), best effort
+	// Failures are logged but do not block the AC CR from reaching Ready, since the current credentials
+	// are valid regardless. Cleanup will be retried on the next reconcile.
+	userOS, userRes, userErr := keystonev1.GetUserServiceClient(
+		ctx, helperObj, keystoneAPI,
+		instance.Spec.UserName,
+		instance.Spec.Secret,
+		instance.Spec.PasswordSelector,
+	)
+	if userErr != nil {
+		logger.Info("Could not build Keystone client; skipping unused rotated AC secret cleanup", "error", userErr)
+	} else if userRes != (ctrl.Result{}) {
+		logger.Info("Keystone client not ready; skipping unused rotated AC secret cleanup")
+	} else {
+		userID, err := r.getUserIDFromToken(ctx, userOS.GetOSClient(), instance.Spec.UserName)
+		if err != nil {
+			logger.Info("Could not get user ID; skipping unused rotated AC secret cleanup", "error", err)
+		} else {
+			if err := r.cleanupUnusedRotatedSecrets(ctx, instance, helperObj, userOS.GetOSClient(), userID); err != nil {
+				logger.Error(err, "Unused rotated AC secret cleanup failed, will retry on next reconcile")
+			}
+		}
+	}
+
 	instance.Status.Conditions.MarkTrue(keystonev1.KeystoneApplicationCredentialReadyCondition, keystonev1.KeystoneApplicationCredentialReadyMessage)
 	return ctrl.Result{}, nil
 }
 
+// reconcileDelete runs when the AC CR is deleted (removed from OpenStackControlPlane or manually)
+// Best-effort: try to revoke Keystone ACs, then remove all protection finalizers
 func (r *ApplicationCredentialReconciler) reconcileDelete(
 	ctx context.Context,
 	instance *keystonev1.KeystoneApplicationCredential,
 	helperObj *helper.Helper,
+	keystoneAPI *keystonev1.KeystoneAPI,
 ) (ctrl.Result, error) {
 	logger := r.GetLogger(ctx)
 	logger.Info("Reconciling ApplicationCredential delete")
 
-	// NOTE: We intentionally do NOT delete the ApplicationCredential from Keystone.
-	// This prevents breaking services (especially EDPM nodes) that are actively using these credentials.
-	// The AC will expire naturally based on its expiration time. If immediate cleanup is needed,
-	// operators can manually delete the AC from Keystone using: openstack application credential delete <ac-id>
+	serviceName := strings.TrimPrefix(instance.Name, "ac-")
 
-	// Before removing our CR finalizer, allow ApplicationCredential Secret to be deleted by removing its protection finalizer
-	if instance.Status.SecretName != "" {
-		key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.SecretName}
-		secret := &corev1.Secret{}
-		if err := helperObj.GetClient().Get(ctx, key, secret); err == nil {
-			if controllerutil.RemoveFinalizer(secret, acSecretFinalizer) {
-				if err := helperObj.GetClient().Update(ctx, secret); err != nil {
-					return ctrl.Result{}, err
-				}
+	// Migrate old mutable secrets before the label-based list query
+	for _, sn := range []string{instance.Status.SecretName, instance.Status.PreviousSecretName} {
+		if sn != "" {
+			if err := r.ensureServiceLabel(ctx, helperObj, sn, instance.Namespace, serviceName); err != nil {
+				logger.Info("Could not ensure service label on secret during delete", "secret", sn, "error", err)
 			}
-		} else if !k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, err
 		}
 	}
 
-	// Remove finalizer from the ApplicationCredential CR, patching is done in the defer function
-	controllerutil.RemoveFinalizer(instance, finalizer)
+	acLabels := map[string]string{
+		"application-credentials":        "true",
+		"application-credential-service": serviceName,
+	}
+	secretList, err := oko_secret.GetSecrets(ctx, helperObj, instance.Namespace, acLabels)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
+	// Build a Keystone client for best-effort revocation (nil if unavailable)
+	var identClient *gophercloud.ServiceClient
+	var userID string
+	if keystoneAPI != nil {
+		userOS, userRes, userErr := keystonev1.GetUserServiceClient(
+			ctx, helperObj, keystoneAPI,
+			instance.Spec.UserName,
+			instance.Spec.Secret,
+			instance.Spec.PasswordSelector,
+		)
+		if userErr != nil || userRes != (ctrl.Result{}) {
+			logger.Info("Could not build Keystone client, skipping revocation during AC CR delete", "error", userErr)
+		} else if uid, err := r.getUserIDFromToken(ctx, userOS.GetOSClient(), instance.Spec.UserName); err != nil {
+			logger.Info("Could not get user ID, skipping revocation during AC CR delete", "error", err)
+		} else {
+			identClient = userOS.GetOSClient()
+			userID = uid
+		}
+	} else {
+		logger.Info("KeystoneAPI not present, skipping Keystone revocation during AC CR delete")
+	}
+
+	// Single pass: revoke ACs in Keystone (best-effort) and strip protection finalizers
+	seen := make(map[string]bool)
+	processed := make(map[string]bool, len(secretList.Items))
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		processed[s.Name] = true
+
+		if identClient != nil {
+			acID := string(s.Data[keystonev1.ACIDSecretKey])
+			if acID != "" && !seen[acID] {
+				seen[acID] = true
+				if err := revokeKeystoneAC(ctx, identClient, userID, acID); err != nil {
+					logger.Info("Keystone revocation failed during AC CR delete, continuing", "ACID", acID, "error", err)
+				} else {
+					logger.Info("Revoked AC in Keystone during AC CR delete", "ACID", acID)
+				}
+			}
+		}
+
+		if controllerutil.RemoveFinalizer(s, acSecretFinalizer) {
+			logger.Info("Removing protection finalizer from AC secret", "secret", s.Name)
+			if err := helperObj.GetClient().Update(ctx, s); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	// Fallback: status-referenced secrets may not appear in the label-based
+	// list if ensureServiceLabel just added the label and the cache hasn't
+	// synced yet. Process them directly to avoid leaving orphaned finalizers
+	for _, sn := range []string{instance.Status.SecretName, instance.Status.PreviousSecretName} {
+		if sn == "" || processed[sn] {
+			continue
+		}
+		fallbackSecret, _, err := oko_secret.GetSecret(ctx, helperObj, sn, instance.Namespace)
+		if err != nil {
+			if k8s_errors.IsNotFound(err) {
+				continue
+			}
+			return ctrl.Result{}, err
+		}
+		if controllerutil.RemoveFinalizer(fallbackSecret, acSecretFinalizer) {
+			logger.Info("Removing protection finalizer from status-referenced AC secret", "secret", sn)
+			if err := helperObj.GetClient().Update(ctx, fallbackSecret); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	controllerutil.RemoveFinalizer(instance, finalizer)
 	return ctrl.Result{}, nil
+}
+
+// revokeKeystoneAC deletes one application credential in Keystone
+// 404 is ignored (already revoked)
+func revokeKeystoneAC(
+	ctx context.Context,
+	identClient *gophercloud.ServiceClient,
+	userID, acID string,
+) error {
+	res := applicationcredentials.Delete(ctx, identClient, userID, acID)
+	if res.Err != nil && !gophercloud.ResponseCodeIs(res.Err, http.StatusNotFound) {
+		return fmt.Errorf("failed to revoke application credential %s in Keystone: %w", acID, res.Err)
+	}
+	return nil
+}
+
+// ensureServiceLabel adds the application-credential-service label to a secret if it's missing
+// This migrates old mutable secrets, so they become visible to label-based queries used by cleanup and deletion
+func (r *ApplicationCredentialReconciler) ensureServiceLabel(
+	ctx context.Context,
+	helperObj *helper.Helper,
+	secretName, namespace, serviceName string,
+) error {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: namespace, Name: secretName}
+	if err := helperObj.GetClient().Get(ctx, key, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if secret.Labels != nil && secret.Labels["application-credential-service"] == serviceName {
+		return nil
+	}
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels["application-credential-service"] = serviceName
+	return helperObj.GetClient().Update(ctx, secret)
+}
+
+// hasConsumerFinalizer returns true if the secret has any finalizer matching the AC consumer convention (suffix: -ac-consumer)
+//
+// Currently the controlplane service operators (barbican, cinder, etc.) place
+// finalizers like "openstack.org/barbican-ac-consumer" on the AC secret they
+// are actively using
+//
+// TODO(OSPRH-28176): EDPM services (nova, ceilometer, aodh) that consume AC
+// secrets on dataplane nodes must also place an EDPM-scoped consumer finalizer
+// (e.g. "openstack.org/edpm-nova-ac-consumer") on the secret. This will
+// prevent the keystone-operator from revoking/deleting a secret that is still
+// deployed to dataplane nodes that have not yet been updated. The EDPM
+// finalizer should only be removed once all nodes across all NodeSets have
+// been redeployed with the new credentials. This depends on per-node secret
+// rotation tracking: https://github.com/openstack-k8s-operators/openstack-operator/pull/1781
+func hasConsumerFinalizer(secret *corev1.Secret) bool {
+	for _, f := range secret.Finalizers {
+		if strings.HasPrefix(f, "openstack.org/") && strings.HasSuffix(f, "-ac-consumer") {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanupUnusedRotatedSecrets runs during reconcileNormal (AC CR is not being deleted)
+// Finds rotated secrets that are neither current nor previous and have no service consumer finalizer
+// For each: revoke its AC in Keystone, remove the protection finalizer, delete the K8s Secret
+func (r *ApplicationCredentialReconciler) cleanupUnusedRotatedSecrets(
+	ctx context.Context,
+	instance *keystonev1.KeystoneApplicationCredential,
+	helperObj *helper.Helper,
+	identClient *gophercloud.ServiceClient,
+	userID string,
+) error {
+	logger := r.GetLogger(ctx)
+	serviceName := strings.TrimPrefix(instance.Name, "ac-")
+
+	secretList, err := oko_secret.GetSecrets(ctx, helperObj, instance.Namespace, map[string]string{
+		"application-credentials":        "true",
+		"application-credential-service": serviceName,
+	})
+	if err != nil {
+		return err
+	}
+
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		if s.Name == instance.Status.SecretName || s.Name == instance.Status.PreviousSecretName || hasConsumerFinalizer(s) {
+			continue
+		}
+
+		acID := string(s.Data[keystonev1.ACIDSecretKey])
+		if acID != "" {
+			if err := revokeKeystoneAC(ctx, identClient, userID, acID); err != nil {
+				return err
+			}
+			logger.Info("Revoked AC in Keystone", "ACID", acID, "secret", s.Name)
+		}
+
+		if controllerutil.RemoveFinalizer(s, acSecretFinalizer) {
+			if err := helperObj.GetClient().Update(ctx, s); err != nil {
+				return fmt.Errorf("failed to remove protection finalizer from %s: %w", s.Name, err)
+			}
+			logger.Info("Removed protection finalizer from AC secret", "secret", s.Name)
+		}
+		if err := helperObj.GetClient().Delete(ctx, s); err != nil && !k8s_errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete AC secret %s: %w", s.Name, err)
+		}
+		logger.Info("Deleted unused rotated AC secret", "secret", s.Name)
+	}
+	return nil
 }
 
 // createACWithName creates a new ApplicationCredential in Keystone
@@ -440,41 +688,76 @@ func (r *ApplicationCredentialReconciler) createACWithName(
 	return created.ID, created.Secret, created.ExpiresAt, nil
 }
 
-func (r *ApplicationCredentialReconciler) storeACSecret(
+// acSecretName returns the unique K8s Secret name for a given service name and
+// Keystone AC ID: ac-<service>-<first5ofACID>-secret.
+func acSecretName(serviceName, acID string) string {
+	idPrefix := acID
+	if len(idPrefix) > 5 {
+		idPrefix = idPrefix[:5]
+	}
+	return fmt.Sprintf("ac-%s-%s-secret", serviceName, idPrefix)
+}
+
+// createImmutableACSecret creates a new immutable K8s Secret with a unique name
+// derived from the AC CR name and the first 5 characters of the Keystone AC ID
+// Each rotation produces a distinct secret; old secrets are retained
+// The protection finalizer is set atomically during creation to avoid a
+// read-after-write cache race that would occur with a separate Get+Update
+func (r *ApplicationCredentialReconciler) createImmutableACSecret(
 	ctx context.Context,
 	helperObj *helper.Helper,
 	ac *keystonev1.KeystoneApplicationCredential,
-	secretName, newID, newSecret string,
-) error {
+	newID, newSecret string,
+) (string, error) {
+	logger := r.GetLogger(ctx)
+
+	serviceName := strings.TrimPrefix(ac.Name, "ac-")
+	secretName := acSecretName(serviceName, newID)
+	immutable := true
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: ac.Namespace,
+			Labels: map[string]string{
+				"application-credentials":        "true",
+				"application-credential-service": serviceName,
+			},
+			Finalizers: []string{acSecretFinalizer},
 		},
-	}
-
-	op, err := controllerutil.CreateOrPatch(ctx, helperObj.GetClient(), secret, func() error {
-		secret.Labels = map[string]string{
-			"application-credentials": "true",
-		}
-		secret.Data = map[string][]byte{
+		Immutable: &immutable,
+		Data: map[string][]byte{
 			keystonev1.ACIDSecretKey:     []byte(newID),
 			keystonev1.ACSecretSecretKey: []byte(newSecret),
+		},
+	}
+	if err := controllerutil.SetControllerReference(ac, secret, helperObj.GetScheme()); err != nil {
+		return "", fmt.Errorf("failed to set controller reference on AC secret %s: %w", secretName, err)
+	}
+
+	if err := helperObj.GetClient().Create(ctx, secret); err != nil {
+		if k8s_errors.IsAlreadyExists(err) {
+			// A secret with this name already exists - most likely a previous reconcile
+			// created it but crashed before patching the status. Validate that the
+			// existing secret's ACID matches the one we intended to store, a mismatch
+			// would indicate an ACID prefix collision (two different Keystone AC IDs
+			// whose first 5 characters are identical, producing the same secret name).
+			existing, _, getErr := oko_secret.GetSecret(ctx, helperObj, secretName, ac.Namespace)
+			if getErr != nil {
+				return "", fmt.Errorf("AC secret %s already exists but failed to fetch for validation: %w", secretName, getErr)
+			}
+			existingACID := string(existing.Data[keystonev1.ACIDSecretKey])
+			if existingACID != newID {
+				return "", fmt.Errorf("%w: secret=%s existingACID=%s expectedACID=%s", errACIDMismatch, secretName, existingACID, newID)
+			}
+			logger.Info("Immutable AC secret already exists with matching ACID, proceeding", "secret", secretName, "ACID", newID)
+			return secretName, nil
 		}
-		// Add protection finalizer
-		controllerutil.AddFinalizer(secret, acSecretFinalizer)
-		// Set owner reference
-		return controllerutil.SetControllerReference(ac, secret, helperObj.GetScheme())
-	})
-	if err != nil {
-		return err
+		return "", fmt.Errorf("failed to create immutable AC secret %s: %w", secretName, err)
 	}
+	logger.Info("Created immutable AC secret", "secret", secretName, "ACID", newID)
 
-	if op != controllerutil.OperationResultNone {
-		r.GetLogger(ctx).Info("Secret operation completed", "secret", secretName, "operation", op)
-	}
-
-	return nil
+	return secretName, nil
 }
 
 // getUserIDFromToken extracts the user ID from the authenticated token
@@ -525,7 +808,14 @@ func needsRotation(ac *keystonev1.KeystoneApplicationCredential) (bool, string, 
 func (r *ApplicationCredentialReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&keystonev1.KeystoneApplicationCredential{}).
-		Owns(&corev1.Secret{}).
+		// Suppress Create events on owned secrets to prevent a race condition:
+		// when a reconcile creates a new immutable secret, the Owns() watch would
+		// immediately enqueue another reconcile. That second reconcile could read
+		// a stale AC CR from the informer cache (status not yet patched) and
+		// duplicate the AC+secret creation. Update and Delete events still trigger reconciles.
+		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(_ event.CreateEvent) bool { return false },
+		})).
 		Complete(r)
 }
 

--- a/internal/controller/keystoneapplicationcredential_controller.go
+++ b/internal/controller/keystoneapplicationcredential_controller.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -29,23 +31,33 @@ import (
 	"github.com/openstack-k8s-operators/keystone-operator/internal/keystone"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	edpm "github.com/openstack-k8s-operators/lib-common/modules/edpm/unstructured"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const acSecretFinalizer = "openstack.org/ac-secret-protection" // #nosec G101
 const finalizer = "openstack.org/applicationcredential"        // #nosec G101
+
+var errACIDMismatch = fmt.Errorf("AC secret already exists with a different ACID")
 
 // ApplicationCredentialReconciler reconciles an ApplicationCredential object
 type ApplicationCredentialReconciler struct {
@@ -59,8 +71,10 @@ type ApplicationCredentialReconciler struct {
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapplicationcredentials,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapplicationcredentials/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapplicationcredentials/finalizers,verbs=update;patch
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=delete
 //+kubebuilder:rbac:groups=core,resources=secrets/finalizers,verbs=get;list;create;update;delete;patch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanenodesets,verbs=get;list;watch
 
 // Reconcile reconciles a KeystoneApplicationCredential resource.
 func (r *ApplicationCredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -140,7 +154,7 @@ func (r *ApplicationCredentialReconciler) Reconcile(ctx context.Context, req ctr
 			// any actual ApplicationCredential, just redirect execution to the "reconcileDelete()"
 			// logic to avoid potentially hanging on waiting for a KeystoneAPI to appear
 			if !instance.DeletionTimestamp.IsZero() {
-				return r.reconcileDelete(ctx, instance, helperObj)
+				return r.reconcileDelete(ctx, instance, helperObj, nil)
 			}
 
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -162,10 +176,11 @@ func (r *ApplicationCredentialReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	// If this KeystoneApplicationCredential CR is being deleted, perform delete cleanup without waiting for KeystoneAPI readiness
-	// NOTE: We don't talk to KeystoneAPI during delete, so KeystoneAPI readiness/deletion check is not needed here
+	// Deletion skips the KeystoneAPI IsReady() check below, so the AC CR is not blocked on readiness
+	// reconcileDelete receives keystoneAPI to attempt best-effort Keystone AC revocation
+	// If Keystone is unreachable (e.g. full teardown), revocation is skipped and finalizers are still removed so the CR deletion is never blocked
 	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance, helperObj)
+		return r.reconcileDelete(ctx, instance, helperObj, keystoneAPI)
 	}
 
 	if !keystoneAPI.IsReady() {
@@ -203,7 +218,8 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 		return ctrl.Result{}, err
 	}
 
-	// Inspect current Secret status
+	// If the current secret was deleted (e.g. manual cleanup, accidental removal),
+	// fall through to rotation so the controller self-heals.
 	if instance.Status.SecretName != "" {
 		secret := &corev1.Secret{}
 		key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.SecretName}
@@ -283,19 +299,37 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 			return ctrl.Result{}, err
 		}
 
-		// Store it in a Secret (create or update)
-		secretName := fmt.Sprintf("%s-secret", instance.Name)
-		if err := r.storeACSecret(ctx, helperObj, instance, secretName, newID, newSecret); err != nil {
+		// Create a new immutable Secret with a unique name
+		secretName, err := r.createImmutableACSecret(ctx, helperObj, instance, newID, newSecret)
+		if err != nil {
+			// The Keystone AC was already created above but its secret cannot be stored.
+			// Revoke it so it doesn't become a permanently orphaned credential in Keystone.
+			if revokeErr := revokeKeystoneAC(ctx, userOS.GetOSClient(), userID, newID); revokeErr != nil {
+				logger.Error(revokeErr, "Failed to revoke orphaned Keystone AC after secret creation failure", "ACID", newID)
+			} else {
+				logger.Info("Revoked orphaned Keystone AC after secret creation failure", "ACID", newID)
+			}
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				keystonev1.KeystoneApplicationCredentialReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				keystonev1.KeystoneApplicationCredentialReadyErrorMessage,
+				fmt.Sprintf("Failed to create AC secret: %s", err.Error()),
+			))
 			return ctrl.Result{}, err
 		}
 
-		// Capture previous expiration before updating status (for rotation event)
+		// Capture previous expiration before updating status — this is the deadline
+		// by which EDPM must be redeployed, since the old credential expires naturally
 		var previousExpiresAt string
 		if isRotation && instance.Status.ExpiresAt != nil {
 			previousExpiresAt = instance.Status.ExpiresAt.Format(time.RFC3339)
 		}
 
-		// Update status
+		// Update status, capture previous secret before rotation for rollback tracking
+		if isRotation && instance.Status.SecretName != "" {
+			instance.Status.PreviousSecretName = instance.Status.SecretName
+		}
 		instance.Status.ACID = newID
 		instance.Status.SecretName = secretName
 		instance.Status.CreatedAt = &metav1.Time{Time: time.Now().UTC()}
@@ -325,8 +359,8 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 				instance,
 				corev1.EventTypeNormal,
 				"ApplicationCredentialRotated",
-				fmt.Sprintf("ApplicationCredential '%s' (user: %s) rotated - EDPM nodes may need credential updates. Previous expiration: %s, New expiration: %s",
-					instance.Name, instance.Spec.UserName, previousExpiresAt, expiresAt.Format(time.RFC3339)),
+				fmt.Sprintf("Rotated credentials for user %s. New expiration: %s, next rotation eligible: %s (grace period: %d days). Previous credential expires: %s",
+					instance.Spec.UserName, expiresAt.Format(time.RFC3339), rotationEligibleAt.Format(time.RFC3339), instance.Spec.GracePeriodDays, previousExpiresAt),
 			)
 
 			logger.Info("ApplicationCredential rotated", "serviceName", instance.Spec.UserName)
@@ -335,7 +369,23 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 		}
 
 		logger.Info("ApplicationCredential ready", "secret", secretName, "ACID", newID, "expiresAt", expiresAt)
-		return ctrl.Result{}, nil
+
+		// Return early after creation/rotation so the defer patches the status.
+		// The status patch triggers a re-reconcile via the For() watch, at which
+		// point the cache is fresh and cleanup of unused rotated secrets can run.
+		// RequeueAfter is a safety net in case the watch event is delayed.
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+	}
+
+	// Migrate old mutable secrets: add the application-credential-service label
+	// if missing, so they become visible to label-based cleanup and deletion queries
+	serviceName := keystonev1.GetServiceNameFromACCR(instance.Name)
+	for _, sn := range []string{instance.Status.SecretName, instance.Status.PreviousSecretName} {
+		if sn != "" {
+			if err := r.ensureServiceLabel(ctx, helperObj, sn, instance.Namespace, serviceName); err != nil {
+				logger.Info("Could not ensure service label on secret", "secret", sn, "error", err)
+			}
+		}
 	}
 
 	// ApplicationCredential already exists and is valid
@@ -346,42 +396,272 @@ func (r *ApplicationCredentialReconciler) reconcileNormal(
 		instance.Status.RotationEligibleAt = &metav1.Time{Time: rotationEligibleAt}
 	}
 
+	// Unused rotated AC secrets (not current/previous, no consumer finalizer), best effort
+	// Failures are logged but do not block the AC CR from reaching Ready, since the current credentials
+	// are valid regardless. Cleanup will be retried on the next reconcile.
+	userOS, userRes, userErr := keystonev1.GetUserServiceClient(
+		ctx, helperObj, keystoneAPI,
+		instance.Spec.UserName,
+		instance.Spec.Secret,
+		instance.Spec.PasswordSelector,
+	)
+	if userErr != nil {
+		logger.Info("Could not build Keystone client; skipping unused rotated AC secret cleanup", "error", userErr)
+	} else if userRes != (ctrl.Result{}) {
+		logger.Info("Keystone client not ready; skipping unused rotated AC secret cleanup")
+	} else {
+		userID, err := r.getUserIDFromToken(ctx, userOS.GetOSClient(), instance.Spec.UserName)
+		if err != nil {
+			logger.Info("Could not get user ID; skipping unused rotated AC secret cleanup", "error", err)
+		} else {
+			if err := r.cleanupUnusedRotatedSecrets(ctx, instance, helperObj, userOS.GetOSClient(), userID); err != nil {
+				logger.Error(err, "Unused rotated AC secret cleanup failed, will retry on next reconcile")
+			}
+		}
+	}
+
 	instance.Status.Conditions.MarkTrue(keystonev1.KeystoneApplicationCredentialReadyCondition, keystonev1.KeystoneApplicationCredentialReadyMessage)
 	return ctrl.Result{}, nil
 }
 
+// reconcileDelete runs when the AC CR is deleted (removed from OpenStackControlPlane or manually)
+// Best-effort: try to revoke Keystone ACs, then remove all protection finalizers
 func (r *ApplicationCredentialReconciler) reconcileDelete(
 	ctx context.Context,
 	instance *keystonev1.KeystoneApplicationCredential,
 	helperObj *helper.Helper,
+	keystoneAPI *keystonev1.KeystoneAPI,
 ) (ctrl.Result, error) {
 	logger := r.GetLogger(ctx)
 	logger.Info("Reconciling ApplicationCredential delete")
 
-	// NOTE: We intentionally do NOT delete the ApplicationCredential from Keystone.
-	// This prevents breaking services (especially EDPM nodes) that are actively using these credentials.
-	// The AC will expire naturally based on its expiration time. If immediate cleanup is needed,
-	// operators can manually delete the AC from Keystone using: openstack application credential delete <ac-id>
+	serviceName := keystonev1.GetServiceNameFromACCR(instance.Name)
 
-	// Before removing our CR finalizer, allow ApplicationCredential Secret to be deleted by removing its protection finalizer
-	if instance.Status.SecretName != "" {
-		key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.SecretName}
-		secret := &corev1.Secret{}
-		if err := helperObj.GetClient().Get(ctx, key, secret); err == nil {
-			if controllerutil.RemoveFinalizer(secret, acSecretFinalizer) {
-				if err := helperObj.GetClient().Update(ctx, secret); err != nil {
-					return ctrl.Result{}, err
-				}
-			}
-		} else if !k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, err
+	// For EDPM-aware ACs, defer deletion until all NodeSet hashes are in sync.
+	// This prevents revoking AC credentials that EDPM nodes may still use
+	// while the controlplane has already switched away and EDPM hasn't been
+	// redeployed. Controlplane-only ACs skip this check entirely.
+	if instance.IsEDPMService() {
+		inSync, syncInfo, err := edpm.AreSecretHashesInSync(ctx, helperObj.GetClient(), instance.Namespace)
+		if err != nil {
+			logger.Info("Could not check NodeSet hash sync during delete, deferring", "error", err)
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+		if !inSync {
+			logger.Info("NodeSet secret hashes out of sync, deferring AC CR deletion",
+				"ac", instance.Name, "info", syncInfo)
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 	}
 
-	// Remove finalizer from the ApplicationCredential CR, patching is done in the defer function
-	controllerutil.RemoveFinalizer(instance, finalizer)
+	// Migrate old mutable secrets before the label-based list query
+	for _, sn := range []string{instance.Status.SecretName, instance.Status.PreviousSecretName} {
+		if sn != "" {
+			if err := r.ensureServiceLabel(ctx, helperObj, sn, instance.Namespace, serviceName); err != nil {
+				logger.Info("Could not ensure service label on secret during delete", "secret", sn, "error", err)
+			}
+		}
+	}
 
+	acLabels := map[string]string{
+		"application-credentials":        "true",
+		"application-credential-service": serviceName,
+	}
+	secretList, err := oko_secret.GetSecrets(ctx, helperObj, instance.Namespace, acLabels)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Build a Keystone client for best-effort revocation (nil if unavailable)
+	var identClient *gophercloud.ServiceClient
+	var userID string
+	if keystoneAPI != nil {
+		userOS, userRes, userErr := keystonev1.GetUserServiceClient(
+			ctx, helperObj, keystoneAPI,
+			instance.Spec.UserName,
+			instance.Spec.Secret,
+			instance.Spec.PasswordSelector,
+		)
+		if userErr != nil || userRes != (ctrl.Result{}) {
+			logger.Info("Could not build Keystone client, skipping revocation during AC CR delete", "error", userErr)
+		} else if uid, err := r.getUserIDFromToken(ctx, userOS.GetOSClient(), instance.Spec.UserName); err != nil {
+			logger.Info("Could not get user ID, skipping revocation during AC CR delete", "error", err)
+		} else {
+			identClient = userOS.GetOSClient()
+			userID = uid
+		}
+	} else {
+		logger.Info("KeystoneAPI not present, skipping Keystone revocation during AC CR delete")
+	}
+
+	// Single pass: revoke ACs in Keystone (best-effort) and strip protection finalizers
+	seen := make(map[string]bool)
+	processed := make(map[string]bool, len(secretList.Items))
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		processed[s.Name] = true
+
+		if identClient != nil {
+			acID := string(s.Data[keystonev1.ACIDSecretKey])
+			if acID != "" && !seen[acID] {
+				seen[acID] = true
+				if err := revokeKeystoneAC(ctx, identClient, userID, acID); err != nil {
+					logger.Info("Keystone revocation failed during AC CR delete, continuing", "ACID", acID, "error", err)
+				} else {
+					logger.Info("Revoked AC in Keystone during AC CR delete", "ACID", acID)
+				}
+			}
+		}
+
+		if controllerutil.RemoveFinalizer(s, acSecretFinalizer) {
+			logger.Info("Removing protection finalizer from AC secret", "secret", s.Name)
+			if err := helperObj.GetClient().Update(ctx, s); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	// Fallback: status-referenced secrets may not appear in the label-based
+	// list if ensureServiceLabel just added the label and the cache hasn't
+	// synced yet. Process them directly to avoid leaving orphaned finalizers
+	for _, sn := range []string{instance.Status.SecretName, instance.Status.PreviousSecretName} {
+		if sn == "" || processed[sn] {
+			continue
+		}
+		fallbackSecret, _, err := oko_secret.GetSecret(ctx, helperObj, sn, instance.Namespace)
+		if err != nil {
+			if k8s_errors.IsNotFound(err) {
+				continue
+			}
+			return ctrl.Result{}, err
+		}
+		if controllerutil.RemoveFinalizer(fallbackSecret, acSecretFinalizer) {
+			logger.Info("Removing protection finalizer from status-referenced AC secret", "secret", sn)
+			if err := helperObj.GetClient().Update(ctx, fallbackSecret); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	controllerutil.RemoveFinalizer(instance, finalizer)
 	return ctrl.Result{}, nil
+}
+
+// revokeKeystoneAC deletes one application credential in Keystone
+// 404 is ignored (already revoked)
+func revokeKeystoneAC(
+	ctx context.Context,
+	identClient *gophercloud.ServiceClient,
+	userID, acID string,
+) error {
+	res := applicationcredentials.Delete(ctx, identClient, userID, acID)
+	if res.Err != nil && !gophercloud.ResponseCodeIs(res.Err, http.StatusNotFound) {
+		return fmt.Errorf("failed to revoke application credential %s in Keystone: %w", acID, res.Err)
+	}
+	return nil
+}
+
+// ensureServiceLabel adds the application-credential-service label to a secret if it's missing
+// This migrates old mutable secrets, so they become visible to label-based queries used by cleanup and deletion
+func (r *ApplicationCredentialReconciler) ensureServiceLabel(
+	ctx context.Context,
+	helperObj *helper.Helper,
+	secretName, namespace, serviceName string,
+) error {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: namespace, Name: secretName}
+	if err := helperObj.GetClient().Get(ctx, key, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if secret.Labels != nil && secret.Labels["application-credential-service"] == serviceName {
+		return nil
+	}
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels["application-credential-service"] = serviceName
+	return helperObj.GetClient().Update(ctx, secret)
+}
+
+// hasConsumerFinalizer returns true if the secret has any finalizer matching the AC consumer convention (suffix: -ac-consumer)
+//
+// Controlplane service operators (barbican, cinder, etc.) place finalizers like
+// "openstack.org/barbican-ac-consumer" on the AC secret they are actively using.
+// EDPM protection is handled separately by checking NodeSet secret hash sync
+// in cleanupUnusedRotatedSecrets before any revocation occurs.
+func hasConsumerFinalizer(secret *corev1.Secret) bool {
+	for _, f := range secret.Finalizers {
+		if strings.HasPrefix(f, "openstack.org/") && strings.HasSuffix(f, "-ac-consumer") {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanupUnusedRotatedSecrets runs during reconcileNormal (AC CR is not being deleted)
+// Finds rotated secrets that are neither current nor previous and have no service consumer finalizer
+// For each: revoke its AC in Keystone, remove the protection finalizer, delete the K8s Secret
+func (r *ApplicationCredentialReconciler) cleanupUnusedRotatedSecrets(
+	ctx context.Context,
+	instance *keystonev1.KeystoneApplicationCredential,
+	helperObj *helper.Helper,
+	identClient *gophercloud.ServiceClient,
+	userID string,
+) error {
+	logger := r.GetLogger(ctx)
+	serviceName := keystonev1.GetServiceNameFromACCR(instance.Name)
+
+	// For EDPM-aware ACs, block revocation while any NodeSet has not yet been
+	// redeployed with the current config secrets. Controlplane-only ACs skip
+	// this check and proceed with cleanup immediately.
+	if instance.IsEDPMService() {
+		inSync, syncInfo, err := edpm.AreSecretHashesInSync(ctx, helperObj.GetClient(), instance.Namespace)
+		if err != nil {
+			logger.Info("Could not check NodeSet hash sync, skipping cleanup", "error", err)
+			return nil
+		}
+		if !inSync {
+			logger.Info("NodeSet secret hashes out of sync, deferring AC cleanup",
+				"ac", instance.Name, "info", syncInfo)
+			return nil
+		}
+	}
+
+	secretList, err := oko_secret.GetSecrets(ctx, helperObj, instance.Namespace, map[string]string{
+		"application-credentials":        "true",
+		"application-credential-service": serviceName,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Revoke ACs in Keystone for each secret that is not the current or previous secret and does not have a consumer finalizer
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		if s.Name == instance.Status.SecretName || s.Name == instance.Status.PreviousSecretName || hasConsumerFinalizer(s) {
+			continue
+		}
+
+		acID := string(s.Data[keystonev1.ACIDSecretKey])
+		if acID != "" && identClient != nil {
+			if err := revokeKeystoneAC(ctx, identClient, userID, acID); err != nil {
+				return err
+			}
+			logger.Info("Revoked AC in Keystone", "ACID", acID, "secret", s.Name)
+		}
+
+		if controllerutil.RemoveFinalizer(s, acSecretFinalizer) {
+			if err := helperObj.GetClient().Update(ctx, s); err != nil {
+				return fmt.Errorf("failed to remove protection finalizer from %s: %w", s.Name, err)
+			}
+			logger.Info("Removed protection finalizer from AC secret", "secret", s.Name)
+		}
+		if err := helperObj.GetClient().Delete(ctx, s); err != nil && !k8s_errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete AC secret %s: %w", s.Name, err)
+		}
+		logger.Info("Deleted unused rotated AC secret", "secret", s.Name)
+	}
+	return nil
 }
 
 // createACWithName creates a new ApplicationCredential in Keystone
@@ -440,41 +720,76 @@ func (r *ApplicationCredentialReconciler) createACWithName(
 	return created.ID, created.Secret, created.ExpiresAt, nil
 }
 
-func (r *ApplicationCredentialReconciler) storeACSecret(
+// acSecretName returns the unique K8s Secret name for a given service name and
+// Keystone AC ID: ac-<service>-<first5ofACID>-secret.
+func acSecretName(serviceName, acID string) string {
+	idPrefix := acID
+	if len(idPrefix) > 5 {
+		idPrefix = idPrefix[:5]
+	}
+	return fmt.Sprintf("ac-%s-%s-secret", serviceName, idPrefix)
+}
+
+// createImmutableACSecret creates a new immutable K8s Secret with a unique name
+// derived from the AC CR name and the first 5 characters of the Keystone AC ID
+// Each rotation produces a distinct secret; old secrets are retained
+// The protection finalizer is set atomically during creation to avoid a
+// read-after-write cache race that would occur with a separate Get+Update
+func (r *ApplicationCredentialReconciler) createImmutableACSecret(
 	ctx context.Context,
 	helperObj *helper.Helper,
 	ac *keystonev1.KeystoneApplicationCredential,
-	secretName, newID, newSecret string,
-) error {
+	newID, newSecret string,
+) (string, error) {
+	logger := r.GetLogger(ctx)
+
+	serviceName := keystonev1.GetServiceNameFromACCR(ac.Name)
+	secretName := acSecretName(serviceName, newID)
+	immutable := true
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: ac.Namespace,
+			Labels: map[string]string{
+				"application-credentials":        "true",
+				"application-credential-service": serviceName,
+			},
+			Finalizers: []string{acSecretFinalizer},
 		},
-	}
-
-	op, err := controllerutil.CreateOrPatch(ctx, helperObj.GetClient(), secret, func() error {
-		secret.Labels = map[string]string{
-			"application-credentials": "true",
-		}
-		secret.Data = map[string][]byte{
+		Immutable: &immutable,
+		Data: map[string][]byte{
 			keystonev1.ACIDSecretKey:     []byte(newID),
 			keystonev1.ACSecretSecretKey: []byte(newSecret),
+		},
+	}
+	if err := controllerutil.SetControllerReference(ac, secret, helperObj.GetScheme()); err != nil {
+		return "", fmt.Errorf("failed to set controller reference on AC secret %s: %w", secretName, err)
+	}
+
+	if err := helperObj.GetClient().Create(ctx, secret); err != nil {
+		if k8s_errors.IsAlreadyExists(err) {
+			// A secret with this name already exists - most likely a previous reconcile
+			// created it but crashed before patching the status. Validate that the
+			// existing secret's ACID matches the one we intended to store, a mismatch
+			// would indicate an ACID prefix collision (two different Keystone AC IDs
+			// whose first 5 characters are identical, producing the same secret name).
+			existing, _, getErr := oko_secret.GetSecret(ctx, helperObj, secretName, ac.Namespace)
+			if getErr != nil {
+				return "", fmt.Errorf("AC secret %s already exists but failed to fetch for validation: %w", secretName, getErr)
+			}
+			existingACID := string(existing.Data[keystonev1.ACIDSecretKey])
+			if existingACID != newID {
+				return "", fmt.Errorf("%w: secret=%s existingACID=%s expectedACID=%s", errACIDMismatch, secretName, existingACID, newID)
+			}
+			logger.Info("Immutable AC secret already exists with matching ACID, proceeding", "secret", secretName, "ACID", newID)
+			return secretName, nil
 		}
-		// Add protection finalizer
-		controllerutil.AddFinalizer(secret, acSecretFinalizer)
-		// Set owner reference
-		return controllerutil.SetControllerReference(ac, secret, helperObj.GetScheme())
-	})
-	if err != nil {
-		return err
+		return "", fmt.Errorf("failed to create immutable AC secret %s: %w", secretName, err)
 	}
+	logger.Info("Created immutable AC secret", "secret", secretName, "ACID", newID)
 
-	if op != controllerutil.OperationResultNone {
-		r.GetLogger(ctx).Info("Secret operation completed", "secret", secretName, "operation", op)
-	}
-
-	return nil
+	return secretName, nil
 }
 
 // getUserIDFromToken extracts the user ID from the authenticated token
@@ -523,10 +838,60 @@ func needsRotation(ac *keystonev1.KeystoneApplicationCredential) (bool, string, 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ApplicationCredentialReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&keystonev1.KeystoneApplicationCredential{}).
-		Owns(&corev1.Secret{}).
-		Complete(r)
+		// Suppress Create events on owned secrets to prevent a race condition:
+		// when a reconcile creates a new immutable secret, the Owns() watch would
+		// immediately enqueue another reconcile. That second reconcile could read
+		// a stale AC CR from the informer cache (status not yet patched) and
+		// duplicate the AC+secret creation. Update and Delete events still trigger reconciles.
+		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(_ event.CreateEvent) bool { return false },
+		}))
+
+	// Only register the NodeSet watch if the dataplane CRD is installed.
+	// Without this guard the informer sync times out and the AC controller
+	// workers never start on clusters without the dataplane-operator.
+	gk := schema.GroupKind{Group: edpm.NodeSetGVK.Group, Kind: edpm.NodeSetGVK.Kind}
+	if _, err := mgr.GetRESTMapper().RESTMapping(gk, edpm.NodeSetGVK.Version); err == nil {
+		b = b.Watches(edpm.NewNodeSetObject(),
+			handler.EnqueueRequestsFromMapFunc(r.nodesetToACMapFunc),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		)
+	}
+
+	return b.Complete(r)
+}
+
+// nodesetToACMapFunc maps any NodeSet change to reconcile requests for all
+// KeystoneApplicationCredential CRs in the same namespace. This allows the
+// controller to re-evaluate cleanup eligibility when EDPM deploys complete.
+func (r *ApplicationCredentialReconciler) nodesetToACMapFunc(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	logger := r.GetLogger(ctx)
+
+	acList := &keystonev1.KeystoneApplicationCredentialList{}
+	if err := r.List(ctx, acList, client.InNamespace(obj.GetNamespace())); err != nil {
+		logger.Error(err, "Failed to list KeystoneApplicationCredential CRs for NodeSet watch")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(acList.Items))
+	for _, ac := range acList.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ac.Name,
+				Namespace: ac.Namespace,
+			},
+		})
+	}
+	if len(requests) > 0 {
+		logger.Info("NodeSet change detected, enqueuing AC CRs for reconciliation",
+			"nodeset", obj.GetName(), "acCount", len(requests))
+	}
+	return requests
 }
 
 // GetLogger returns a logger configured for this controller.

--- a/internal/controller/keystoneapplicationcredential_edpm_test.go
+++ b/internal/controller/keystoneapplicationcredential_edpm_test.go
@@ -1,0 +1,494 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
+	edpm "github.com/openstack-k8s-operators/lib-common/modules/edpm/unstructured"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(keystonev1.AddToScheme(s))
+	return s
+}
+
+func newTestRESTMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "dataplane.openstack.org", Version: "v1beta1"},
+	})
+	mapper.Add(edpm.NodeSetGVK, meta.RESTScopeNamespace)
+	return mapper
+}
+
+func makeNodeSet(name, namespace string, secretHashes map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(edpm.NodeSetGVK)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	if len(secretHashes) > 0 {
+		hashes := map[string]interface{}{}
+		for k, v := range secretHashes {
+			hashes[k] = v
+		}
+		obj.Object["status"] = map[string]interface{}{
+			"secretHashes": hashes,
+		}
+	}
+	return obj
+}
+
+func makeACSecret(name, namespace, serviceName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"application-credentials":        "true",
+				"application-credential-service": serviceName,
+			},
+			Finalizers: []string{acSecretFinalizer},
+		},
+		Data: map[string][]byte{
+			keystonev1.ACIDSecretKey:     {},
+			keystonev1.ACSecretSecretKey: []byte("fake-secret"),
+		},
+	}
+}
+
+func TestCleanupUnusedRotatedSecrets_BlockedByStaleNodeSet(t *testing.T) {
+	ns := "test-blocking"
+	serviceName := "nova"
+	configSecretName := "nova-config"
+
+	configSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: configSecretName, Namespace: ns},
+		Data:       map[string][]byte{"config": []byte("new-config-data")},
+	}
+	configHash, err := oko_secret.Hash(configSecret)
+	if err != nil {
+		t.Fatalf("failed to hash config secret: %v", err)
+	}
+
+	// NodeSet reports a stale hash — EDPM has NOT been redeployed yet
+	nodeset := makeNodeSet("edpm-compute", ns, map[string]string{
+		configSecretName: configHash + "-stale",
+	})
+
+	acSecret := makeACSecret("ac-nova-old-secret", ns, serviceName)
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(configSecret, acSecret).
+		WithStatusSubresource(&keystonev1.KeystoneApplicationCredential{}).
+		WithObjects(nodeset).
+		Build()
+
+	instance := &keystonev1.KeystoneApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ac-" + serviceName,
+			Namespace: ns,
+			Annotations: map[string]string{
+				keystonev1.EDPMServiceAnnotation: "true",
+			},
+		},
+		Status: keystonev1.KeystoneApplicationCredentialStatus{
+			SecretName:         "ac-nova-current-secret",
+			PreviousSecretName: "ac-nova-previous-secret",
+		},
+	}
+
+	kclient := k8sfake.NewSimpleClientset(acSecret)
+	helperObj, err := helper.NewHelper(instance, c, kclient, s, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to create helper: %v", err)
+	}
+
+	reconciler := &ApplicationCredentialReconciler{
+		Client: c,
+		Scheme: s,
+		Log:    logr.Discard(),
+	}
+
+	err = reconciler.cleanupUnusedRotatedSecrets(context.Background(), instance, helperObj, nil, "")
+	if err != nil {
+		t.Fatalf("cleanupUnusedRotatedSecrets returned error: %v", err)
+	}
+
+	// The AC secret must still exist — cleanup was blocked by stale NodeSet
+	preserved := &corev1.Secret{}
+	err = c.Get(context.Background(), types.NamespacedName{Name: acSecret.Name, Namespace: ns}, preserved)
+	if err != nil {
+		t.Fatalf("AC secret was deleted but should have been preserved (EDPM out of sync): %v", err)
+	}
+	if len(preserved.Finalizers) == 0 || preserved.Finalizers[0] != acSecretFinalizer {
+		t.Errorf("AC secret finalizer was modified; expected %s, got %v", acSecretFinalizer, preserved.Finalizers)
+	}
+}
+
+func TestCleanupUnusedRotatedSecrets_ProceedsWithoutNodeSets(t *testing.T) {
+	ns := "test-no-nodesets"
+	serviceName := "nova"
+
+	// AC secret with empty ACID so Keystone revocation is skipped
+	acSecret := makeACSecret("ac-nova-old-secret", ns, serviceName)
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(acSecret).
+		WithStatusSubresource(&keystonev1.KeystoneApplicationCredential{}).
+		Build()
+
+	instance := &keystonev1.KeystoneApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{Name: "ac-" + serviceName, Namespace: ns},
+		Status: keystonev1.KeystoneApplicationCredentialStatus{
+			SecretName:         "ac-nova-current-secret",
+			PreviousSecretName: "ac-nova-previous-secret",
+		},
+	}
+
+	kclient := k8sfake.NewSimpleClientset(acSecret)
+	helperObj, err := helper.NewHelper(instance, c, kclient, s, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to create helper: %v", err)
+	}
+
+	reconciler := &ApplicationCredentialReconciler{
+		Client: c,
+		Scheme: s,
+		Log:    logr.Discard(),
+	}
+
+	err = reconciler.cleanupUnusedRotatedSecrets(context.Background(), instance, helperObj, nil, "")
+	if err != nil {
+		t.Fatalf("cleanupUnusedRotatedSecrets returned error: %v", err)
+	}
+
+	// The AC secret should be deleted — no NodeSets means hashes are in sync
+	deleted := &corev1.Secret{}
+	err = c.Get(context.Background(), types.NamespacedName{Name: acSecret.Name, Namespace: ns}, deleted)
+	if err == nil {
+		t.Fatalf("AC secret still exists but should have been deleted (no NodeSets, cleanup should proceed)")
+	}
+	if client.IgnoreNotFound(err) != nil {
+		t.Fatalf("unexpected error checking for deleted secret: %v", err)
+	}
+}
+
+func TestReconcileDelete_EDPMServiceBlockedByStaleNodeSet(t *testing.T) {
+	ns := "test-delete-blocked"
+	serviceName := "nova"
+	configSecretName := "nova-config"
+
+	configSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: configSecretName, Namespace: ns},
+		Data:       map[string][]byte{"config": []byte("new-config-data")},
+	}
+	configHash, err := oko_secret.Hash(configSecret)
+	if err != nil {
+		t.Fatalf("failed to hash config secret: %v", err)
+	}
+
+	nodeset := makeNodeSet("edpm-compute", ns, map[string]string{
+		configSecretName: configHash + "-stale",
+	})
+
+	now := metav1.Now()
+	instance := &keystonev1.KeystoneApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "ac-" + serviceName,
+			Namespace:         ns,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizer},
+			Annotations: map[string]string{
+				keystonev1.EDPMServiceAnnotation: "true",
+			},
+		},
+		Spec: keystonev1.KeystoneApplicationCredentialSpec{
+			UserName: serviceName,
+			Secret:   "osp-secret",
+		},
+		Status: keystonev1.KeystoneApplicationCredentialStatus{
+			SecretName: "ac-nova-abc12-secret",
+		},
+	}
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(configSecret, nodeset).
+		WithStatusSubresource(&keystonev1.KeystoneApplicationCredential{}).
+		Build()
+
+	kclient := k8sfake.NewSimpleClientset()
+	helperObj, err := helper.NewHelper(instance, c, kclient, s, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to create helper: %v", err)
+	}
+
+	reconciler := &ApplicationCredentialReconciler{
+		Client: c,
+		Scheme: s,
+		Log:    logr.Discard(),
+	}
+
+	result, err := reconciler.reconcileDelete(context.Background(), instance, helperObj, nil)
+	if err != nil {
+		t.Fatalf("reconcileDelete returned error: %v", err)
+	}
+
+	// EDPM-aware AC with stale NodeSet hashes returns RequeueAfter as a
+	// safety net; the NodeSet watch also triggers a reconcile on updates.
+	expected := ctrl.Result{RequeueAfter: time.Minute}
+	if result != expected {
+		t.Fatalf("reconcileDelete returned %v; expected %v (EDPM out of sync)", result, expected)
+	}
+
+	// Finalizer must still be present — deletion was blocked
+	if len(instance.Finalizers) == 0 {
+		t.Fatal("finalizer was removed but should have been preserved (EDPM out of sync)")
+	}
+}
+
+func TestReconcileDelete_ProceedsWhenHashesInSync(t *testing.T) {
+	ns := "test-delete-synced"
+	serviceName := "barbican"
+	configSecretName := "nova-config"
+
+	configSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: configSecretName, Namespace: ns},
+		Data:       map[string][]byte{"config": []byte("config-data")},
+	}
+	configHash, err := oko_secret.Hash(configSecret)
+	if err != nil {
+		t.Fatalf("failed to hash config secret: %v", err)
+	}
+
+	// NodeSet hashes are IN SYNC — EDPM has been redeployed
+	nodeset := makeNodeSet("edpm-compute", ns, map[string]string{
+		configSecretName: configHash,
+	})
+
+	now := metav1.Now()
+	instance := &keystonev1.KeystoneApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "ac-" + serviceName,
+			Namespace:         ns,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizer},
+			Annotations: map[string]string{
+				keystonev1.EDPMServiceAnnotation: "false",
+			},
+		},
+		Spec: keystonev1.KeystoneApplicationCredentialSpec{
+			UserName: serviceName,
+			Secret:   "osp-secret",
+		},
+		Status: keystonev1.KeystoneApplicationCredentialStatus{
+			SecretName: "ac-barbican-abc12-secret",
+		},
+	}
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(configSecret, nodeset).
+		WithStatusSubresource(&keystonev1.KeystoneApplicationCredential{}).
+		Build()
+
+	kclient := k8sfake.NewSimpleClientset()
+	helperObj, err := helper.NewHelper(instance, c, kclient, s, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to create helper: %v", err)
+	}
+
+	reconciler := &ApplicationCredentialReconciler{
+		Client: c,
+		Scheme: s,
+		Log:    logr.Discard(),
+	}
+
+	result, err := reconciler.reconcileDelete(context.Background(), instance, helperObj, nil)
+	if err != nil {
+		t.Fatalf("reconcileDelete returned error: %v", err)
+	}
+
+	if result != (ctrl.Result{}) {
+		t.Fatalf("reconcileDelete returned non-empty result %v; expected empty (non-EDPM service)", result)
+	}
+
+	// Finalizer should have been removed — deletion proceeds
+	if len(instance.Finalizers) != 0 {
+		t.Fatalf("finalizer was not removed; got %v", instance.Finalizers)
+	}
+}
+
+func TestReconcileDelete_NonEDPMServiceProceedsDespiteStaleHashes(t *testing.T) {
+	ns := "test-delete-non-edpm"
+	serviceName := "heat"
+	configSecretName := "heat-config"
+
+	configSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: configSecretName, Namespace: ns},
+		Data:       map[string][]byte{"config": []byte("config-data")},
+	}
+	configHash, err := oko_secret.Hash(configSecret)
+	if err != nil {
+		t.Fatalf("failed to hash config secret: %v", err)
+	}
+
+	// NodeSet hashes are STALE, but this AC is explicitly non-EDPM
+	nodeset := makeNodeSet("edpm-compute", ns, map[string]string{
+		configSecretName: configHash + "-stale",
+	})
+
+	now := metav1.Now()
+	instance := &keystonev1.KeystoneApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "ac-" + serviceName,
+			Namespace:         ns,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizer},
+			Annotations: map[string]string{
+				keystonev1.EDPMServiceAnnotation: "false",
+			},
+		},
+		Spec: keystonev1.KeystoneApplicationCredentialSpec{
+			UserName: serviceName,
+			Secret:   "osp-secret",
+		},
+		Status: keystonev1.KeystoneApplicationCredentialStatus{
+			SecretName: "ac-heat-abc12-secret",
+		},
+	}
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(configSecret, nodeset).
+		WithStatusSubresource(&keystonev1.KeystoneApplicationCredential{}).
+		Build()
+
+	kclient := k8sfake.NewSimpleClientset()
+	helperObj, err := helper.NewHelper(instance, c, kclient, s, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to create helper: %v", err)
+	}
+
+	reconciler := &ApplicationCredentialReconciler{
+		Client: c,
+		Scheme: s,
+		Log:    logr.Discard(),
+	}
+
+	result, err := reconciler.reconcileDelete(context.Background(), instance, helperObj, nil)
+	if err != nil {
+		t.Fatalf("reconcileDelete returned error: %v", err)
+	}
+
+	if result != (ctrl.Result{}) {
+		t.Fatalf("reconcileDelete returned %v; expected empty (non-EDPM service skips hash check)", result)
+	}
+
+	if len(instance.Finalizers) != 0 {
+		t.Fatalf("finalizer was not removed; got %v", instance.Finalizers)
+	}
+}
+
+func TestReconcileDelete_MissingAnnotationBlockedByStaleNodeSet(t *testing.T) {
+	ns := "test-delete-missing-annotation"
+	serviceName := "unknown-service"
+	configSecretName := "config-secret"
+
+	configSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: configSecretName, Namespace: ns},
+		Data:       map[string][]byte{"config": []byte("data")},
+	}
+	configHash, err := oko_secret.Hash(configSecret)
+	if err != nil {
+		t.Fatalf("failed to hash config secret: %v", err)
+	}
+
+	// NodeSet hashes are STALE and the AC has NO annotation (fail-safe: treat as EDPM)
+	nodeset := makeNodeSet("edpm-compute", ns, map[string]string{
+		configSecretName: configHash + "-stale",
+	})
+
+	now := metav1.Now()
+	instance := &keystonev1.KeystoneApplicationCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "ac-" + serviceName,
+			Namespace:         ns,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{finalizer},
+		},
+		Spec: keystonev1.KeystoneApplicationCredentialSpec{
+			UserName: serviceName,
+			Secret:   "osp-secret",
+		},
+		Status: keystonev1.KeystoneApplicationCredentialStatus{
+			SecretName: "ac-unknown-abc12-secret",
+		},
+	}
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(newTestRESTMapper()).
+		WithObjects(configSecret, nodeset).
+		WithStatusSubresource(&keystonev1.KeystoneApplicationCredential{}).
+		Build()
+
+	kclient := k8sfake.NewSimpleClientset()
+	helperObj, err := helper.NewHelper(instance, c, kclient, s, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to create helper: %v", err)
+	}
+
+	reconciler := &ApplicationCredentialReconciler{
+		Client: c,
+		Scheme: s,
+		Log:    logr.Discard(),
+	}
+
+	result, err := reconciler.reconcileDelete(context.Background(), instance, helperObj, nil)
+	if err != nil {
+		t.Fatalf("reconcileDelete returned error: %v", err)
+	}
+
+	// Missing annotation defaults to EDPM-aware (fail-safe), so stale hashes block deletion
+	expected := ctrl.Result{RequeueAfter: time.Minute}
+	if result != expected {
+		t.Fatalf("reconcileDelete returned %v; expected %v (missing annotation = fail-safe EDPM-aware)", result, expected)
+	}
+
+	if len(instance.Finalizers) == 0 {
+		t.Fatal("finalizer was removed but should have been preserved (fail-safe EDPM-aware)")
+	}
+}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -23,13 +23,14 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	keystone_base "github.com/openstack-k8s-operators/keystone-operator/internal/keystone"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetKeystoneAPISpec(fernetMaxKeys int32) map[string]any {
@@ -208,6 +209,13 @@ func GetExtraMounts(kemName string, kemPath string) []map[string]any {
 }
 
 // ApplicationCredential helper functions
+
+// Finalizer constants used across AC tests
+const (
+	ACCRFinalizer               = "openstack.org/applicationcredential"
+	ACSecretProtectionFinalizer = "openstack.org/ac-secret-protection" //nolint:gosec
+)
+
 func CreateACWithSpec(name types.NamespacedName, spec map[string]interface{}) client.Object {
 	raw := map[string]interface{}{
 		"apiVersion": "keystone.openstack.org/v1beta1",
@@ -219,6 +227,98 @@ func CreateACWithSpec(name types.NamespacedName, spec map[string]interface{}) cl
 		"spec": spec,
 	}
 	return th.CreateUnstructured(raw)
+}
+
+// GetDefaultACSpec returns a minimal, valid AC spec. Callers that need
+// non-default values (roles, accessRules, etc.) should build their own map
+func GetDefaultACSpec(userName, secretName string) map[string]interface{} {
+	return map[string]interface{}{
+		"userName":         userName,
+		"secret":           secretName,
+		"passwordSelector": "ServicePassword",
+		"expirationDays":   30,
+		"gracePeriodDays":  7,
+		"roles":            []string{"service"},
+	}
+}
+
+// CreateACServiceUserSecret creates the standard service-user Secret
+// (key: ServicePassword) used by AC tests and returns its NamespacedName
+func CreateACServiceUserSecret(namespace string) types.NamespacedName {
+	name := types.NamespacedName{Name: "osp-secret", Namespace: namespace}
+	th.CreateSecret(name, map[string][]byte{
+		"ServicePassword": []byte("service-password"),
+	})
+	return name
+}
+
+// CreateProtectedACSecret creates an immutable Kubernetes Secret with the
+// AC label set and the protection finalizer already applied, simulating a
+// secret that was created during a previous reconcile or rotation
+func CreateProtectedACSecret(name types.NamespacedName, serviceName string) *corev1.Secret {
+	immutable := true
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Labels: map[string]string{
+				"application-credentials":        "true",
+				"application-credential-service": serviceName,
+			},
+			Finalizers: []string{ACSecretProtectionFinalizer},
+		},
+		Immutable: &immutable,
+		Data: map[string][]byte{
+			keystonev1.ACIDSecretKey:     []byte("fake-ac-id"),
+			keystonev1.ACSecretSecretKey: []byte("fake-ac-secret"),
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+	return secret
+}
+
+// CreateOldStyleACSecret creates a mutable secret with only the
+// application-credentials label (no application-credential-service label),
+// simulating a secret created by the pre-immutable secret logic
+func CreateOldStyleACSecret(name types.NamespacedName, acID string) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Labels: map[string]string{
+				"application-credentials": "true",
+			},
+			Finalizers: []string{ACSecretProtectionFinalizer},
+		},
+		Data: map[string][]byte{
+			keystonev1.ACIDSecretKey:     []byte(acID),
+			keystonev1.ACSecretSecretKey: []byte("fake-ac-secret"),
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+	return secret
+}
+
+// WaitForACFinalizer blocks until the AC CR carries its controller finalizer
+func WaitForACFinalizer(name types.NamespacedName) {
+	Eventually(func(g Gomega) {
+		ac := GetApplicationCredential(name)
+		g.Expect(ac.Finalizers).To(ContainElement(ACCRFinalizer))
+	}, timeout, interval).Should(Succeed())
+}
+
+// DeleteACCR issues a delete on the AC CR. It does not wait for the CR to disappear
+func DeleteACCR(name types.NamespacedName) {
+	acInstance := GetApplicationCredential(name)
+	Expect(k8sClient.Delete(ctx, acInstance)).To(Succeed())
+}
+
+// WaitForACGone blocks until the AC CR is fully removed from the API server
+func WaitForACGone(name types.NamespacedName) {
+	Eventually(func(g Gomega) {
+		err := k8sClient.Get(ctx, name, &keystonev1.KeystoneApplicationCredential{})
+		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
+	}, timeout, interval).Should(Succeed())
 }
 
 func GetApplicationCredential(name types.NamespacedName) *keystonev1.KeystoneApplicationCredential {

--- a/test/functional/keystoneapi_controller_test.go
+++ b/test/functional/keystoneapi_controller_test.go
@@ -2614,39 +2614,127 @@ OIDCRedirectURI "{{ .KeystoneEndpointPublic }}/v3/auth/OS-FEDERATION/websso/open
 		})
 
 		It("should handle deletion with finalizer cleanup", func() {
-			serviceUserSecret := types.NamespacedName{Name: "osp-secret", Namespace: namespace}
-			th.CreateSecret(serviceUserSecret, map[string][]byte{
-				"ServicePassword": []byte("service-password"),
-			})
+			userSecret := CreateACServiceUserSecret(namespace)
 
 			deleteACName := types.NamespacedName{Name: "ac-delete-test", Namespace: namespace}
-			CreateACWithSpec(deleteACName, map[string]interface{}{
-				"userName":         "test-service",
-				"secret":           serviceUserSecret.Name,
-				"passwordSelector": "ServicePassword",
-				"expirationDays":   30,
-				"gracePeriodDays":  7,
-				"roles":            []string{"service"},
-			})
+			CreateACWithSpec(deleteACName, GetDefaultACSpec("test-service", userSecret.Name))
+			WaitForACFinalizer(deleteACName)
 
+			// The controller removes its own finalizer during reconcileDelete, so the CR should be fully deleted
+			DeleteACCR(deleteACName)
+			WaitForACGone(deleteACName)
+		})
+
+		It("should remove the protection finalizer from all AC secrets for the service on deletion", func() {
+			userSecret := CreateACServiceUserSecret(namespace)
+
+			deleteACName := types.NamespacedName{Name: "ac-multi-secret-svc", Namespace: namespace}
+			CreateACWithSpec(deleteACName, GetDefaultACSpec("multi-secret-svc", userSecret.Name))
+			WaitForACFinalizer(deleteACName)
+
+			// Simulate two immutable AC secrets left from an initial creation and one rotation
+			firstSecretName := types.NamespacedName{Name: "ac-multi-secret-svc-aaaaa-secret", Namespace: namespace}
+			secondSecretName := types.NamespacedName{Name: "ac-multi-secret-svc-bbbbb-secret", Namespace: namespace}
+			CreateProtectedACSecret(firstSecretName, "multi-secret-svc")
+			CreateProtectedACSecret(secondSecretName, "multi-secret-svc")
+
+			// Both secrets must start protected
+			for _, sName := range []types.NamespacedName{firstSecretName, secondSecretName} {
+				s := &corev1.Secret{}
+				Expect(k8sClient.Get(ctx, sName, s)).To(Succeed())
+				Expect(s.Finalizers).To(ContainElement(ACSecretProtectionFinalizer))
+			}
+
+			DeleteACCR(deleteACName)
+
+			// The controller should strip the protection finalizer from every secret carrying the service label, and not just Status.SecretName
 			Eventually(func(g Gomega) {
-				ac := GetApplicationCredential(deleteACName)
-				g.Expect(ac.Finalizers).To(ContainElement("openstack.org/applicationcredential"))
+				for _, sName := range []types.NamespacedName{firstSecretName, secondSecretName} {
+					s := &corev1.Secret{}
+					g.Expect(k8sClient.Get(ctx, sName, s)).To(Succeed())
+					g.Expect(s.Finalizers).NotTo(ContainElement(ACSecretProtectionFinalizer),
+						"secret %s should have its protection finalizer removed", sName.Name)
+				}
 			}, timeout, interval).Should(Succeed())
 
-			acInstance := GetApplicationCredential(deleteACName)
-			err := k8sClient.Delete(ctx, acInstance)
-			Expect(err).NotTo(HaveOccurred())
+			WaitForACGone(deleteACName)
+		})
 
+		It("should not remove AC secrets belonging to a different service on deletion", func() {
+			userSecret := CreateACServiceUserSecret(namespace)
+
+			acSvc1Name := types.NamespacedName{Name: "ac-svc-alpha", Namespace: namespace}
+			acSvc2Name := types.NamespacedName{Name: "ac-svc-beta", Namespace: namespace}
+			for _, name := range []types.NamespacedName{acSvc1Name, acSvc2Name} {
+				CreateACWithSpec(name, GetDefaultACSpec(name.Name, userSecret.Name))
+			}
+			for _, name := range []types.NamespacedName{acSvc1Name, acSvc2Name} {
+				WaitForACFinalizer(name)
+			}
+
+			svc1SecretName := types.NamespacedName{Name: "ac-svc-alpha-ccccc-secret", Namespace: namespace}
+			svc2SecretName := types.NamespacedName{Name: "ac-svc-beta-ddddd-secret", Namespace: namespace}
+			CreateProtectedACSecret(svc1SecretName, "svc-alpha")
+			CreateProtectedACSecret(svc2SecretName, "svc-beta")
+
+			// Delete only ac-svc-alpha
+			DeleteACCR(acSvc1Name)
+
+			// svc-alpha secret must lose its finalizer
+			Eventually(func(g Gomega) {
+				s := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, svc1SecretName, s)).To(Succeed())
+				g.Expect(s.Finalizers).NotTo(ContainElement(ACSecretProtectionFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			// svc-beta secret must keep its finalizer throughout
+			Consistently(func(g Gomega) {
+				s := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, svc2SecretName, s)).To(Succeed())
+				g.Expect(s.Finalizers).To(ContainElement(ACSecretProtectionFinalizer),
+					"svc-beta secret should retain its protection finalizer")
+			}, "3s", interval).Should(Succeed())
+		})
+
+		It("should migrate old mutable secrets by adding the service label on deletion", func() {
+			userSecret := CreateACServiceUserSecret(namespace)
+
+			acName := types.NamespacedName{Name: "ac-migrate-svc", Namespace: namespace}
+			CreateACWithSpec(acName, GetDefaultACSpec("migrate-svc", userSecret.Name))
+			WaitForACFinalizer(acName)
+
+			oldSecretName := types.NamespacedName{Name: "ac-migrate-svc-secret", Namespace: namespace}
+			CreateOldStyleACSecret(oldSecretName, "old-ac-id-12345")
+
+			// Patch status to point to the old-style secret (simulating upgrade from old controller)
 			Eventually(func(g Gomega) {
 				ac := &keystonev1.KeystoneApplicationCredential{}
-				err := k8sClient.Get(ctx, deleteACName, ac)
-				if k8s_errors.IsNotFound(err) {
-					return
-				}
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(ac.DeletionTimestamp).NotTo(BeNil())
+				g.Expect(k8sClient.Get(ctx, acName, ac)).To(Succeed())
+				ac.Status.ACID = "old-ac-id-12345"
+				ac.Status.SecretName = oldSecretName.Name
+				g.Expect(k8sClient.Status().Update(ctx, ac)).To(Succeed())
 			}, timeout, interval).Should(Succeed())
+
+			// Verify the old secret does not have the service label yet
+			oldSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, oldSecretName, oldSecret)).To(Succeed())
+			Expect(oldSecret.Labels).NotTo(HaveKey("application-credential-service"))
+
+			DeleteACCR(acName)
+
+			// reconcileDelete calls ensureServiceLabel before the label-based
+			// list query, so the old secret should get the service label added
+			// and then have its protection finalizer removed
+			Eventually(func(g Gomega) {
+				s := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, oldSecretName, s)).To(Succeed())
+				g.Expect(s.Labels).To(HaveKeyWithValue(
+					"application-credential-service", "migrate-svc"))
+				g.Expect(s.Finalizers).NotTo(ContainElement(ACSecretProtectionFinalizer),
+					"old-style secret should have its protection finalizer removed after migration")
+			}, timeout, interval).Should(Succeed())
+
+			WaitForACGone(acName)
 		})
 
 		It("should validate expiration vs grace period constraints", func() {

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -98,6 +98,8 @@ var _ = BeforeSuite(func() {
 	infraCRDs, err := test.GetCRDDirFromModule(
 		"github.com/openstack-k8s-operators/infra-operator/apis", "../../go.mod", "bases")
 	Expect(err).ShouldNot(HaveOccurred())
+	dataplaneCRDs, err := test.GetDataPlaneCRDDir("../../go.mod")
+	Expect(err).ShouldNot(HaveOccurred())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -105,6 +107,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "..", "config", "crd", "bases"),
 			mariaDBCRDs,
 			infraCRDs,
+			dataplaneCRDs,
 		},
 		// Increase this to 60 or 120 seconds for the single-core run
 		ControlPlaneStartTimeout: 120 * time.Second,


### PR DESCRIPTION
Jira: [OSPRH-28176](https://redhat.atlassian.net/browse/OSPRH-28176), [OSPRH-27512](https://redhat.atlassian.net/browse/OSPRH-27512), [OSPRH-27519](https://redhat.atlassian.net/browse/OSPRH-27519)

Application Credential dev-doc: https://github.com/openstack-k8s-operators/dev-docs/blob/main/application_credentials.md

* Delete unused `GetApplicationCredentialFromSecret` function
* Add a service label to the AC  secret for easy discovery, e.g. `application-credential-service: barbican`
* Introduce immutable per-rotation AC secrets with deterministic names
*  Add a new status field `previousSecretName` used for tracking previously used AC secret 
* Add Keystone-side revocation of unused rotated ACs - currently used secret and previously used secret are protected, pre-previous secret is deleted and revoked
* Suppress Owns() create events on the secret watch to prevent a race condition caused by stale informer cach and sometimes causing additional AC secret to be created and deleted immediately during app cred rotation
* Add migration support for old mutable secrets - on the first reconcile after upgrade, the `application-credential-service ` label is added to any existing secret that lacks it, making it visible to the label-based deletion. This ensures old secrets are properly revoked and cleaned up on the next rotation or CR deletion, and prevents orphaned protection finalizers 
* Add EDPM-aware guards on both cleanup and deletion paths using `edpm.AreSecretHashesInSync()` from https://github.com/openstack-k8s-operators/lib-common/tree/main/modules/edpm. Before revoking rotated AC secrets or proceeding with AC CR deletion, the controller checks that all `OpenStackDataPlaneNodeSet` resources have been redeployed with the current config secrets. If any NodeSet has stale hashes, action is deferred until the next EDPM deploy. The controller watches NodeSet resources (via unstructured access to avoid circular dependencies) and re-evaluates when a NodeSet status changes. All AC CRs are checked uniformly - no hardcoded EDPM service mapping. This approach is aligned with the RabbitMQ user deletion design in infra-operator.

Each service operator that consumes an AC secret now places a `openstack.org/<service>-ac-consumer` finalizer on the AC secret it is actively using. This ensures the keystone-operator cannot revoke or clean up secret while a service is still holding a reference to it.



Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/693