### PR TITLE
Ensure stable condition messages by sorting map iterations

### DIFF
--- a/internal/controller/keystoneapi_controller.go
+++ b/internal/controller/keystoneapi_controller.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"sort"
+	"slices"
 	"strconv"
 	"time"
 
@@ -616,7 +616,8 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 	}
 
 	apiEndpoints := make(map[string]string)
-	for endpointType, data := range keystoneEndpoints {
+	for _, endpointType := range slices.Sorted(maps.Keys(keystoneEndpoints)) {
+		data := keystoneEndpoints[endpointType]
 		endpointTypeStr := string(endpointType)
 		endpointName := instance.Name + "-" + endpointTypeStr
 
@@ -802,7 +803,8 @@ func (r *KeystoneAPIReconciler) reconcileExternalKeystoneAPI(
 	publicEndpointURL := ""
 	internalEndpointURL := ""
 
-	for endpointType, data := range instance.Spec.Override.Service {
+	for _, endpointType := range slices.Sorted(maps.Keys(instance.Spec.Override.Service)) {
+		data := instance.Spec.Override.Service[endpointType]
 		if endpointType == service.EndpointPublic {
 			hasPublic = true
 			if data.EndpointURL == nil || *data.EndpointURL == "" {
@@ -1604,7 +1606,8 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 		endptConfig["Override"] = false
 		if len(httpdOverrideSecret.Data) > 0 {
 			endptConfig["Override"] = true
-			for key, data := range httpdOverrideSecret.Data {
+			for _, key := range slices.Sorted(maps.Keys(httpdOverrideSecret.Data)) {
+				data := httpdOverrideSecret.Data[key]
 				if len(data) > 0 {
 					customTemplates["httpd_custom_"+endpt.String()+"_"+key] = string(data)
 				}
@@ -1925,11 +1928,7 @@ func (r *KeystoneAPIReconciler) ensureFederationRealmConfig(
 	}
 
 	// Extract and Sort Filenames (Keys)
-	var sortedFilenames []string
-	for filename := range rawConfigs {
-		sortedFilenames = append(sortedFilenames, filename)
-	}
-	sort.Strings(sortedFilenames)
+	sortedFilenames := slices.Sorted(maps.Keys(rawConfigs))
 
 	// Prepare data for the new Secret
 	newSecretData := make(map[string]string)

--- a/internal/controller/keystoneendpoint_controller.go
+++ b/internal/controller/keystoneendpoint_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -267,7 +268,7 @@ func (r *KeystoneEndpointReconciler) reconcileDelete(
 	if os != nil {
 		// Delete Endpoints -  it is ok to call delete on non existing Endpoints
 		// therefore always call delete for the spec.
-		for endpointType := range instance.Spec.Endpoints {
+		for _, endpointType := range slices.Sorted(maps.Keys(instance.Spec.Endpoints)) {
 			// get the gopher availability mapping for the endpointInterface
 			availability, err := openstack.GetAvailability(endpointType)
 			if err != nil {
@@ -441,10 +442,15 @@ func (r *KeystoneEndpointReconciler) reconcileNormal(
 			err.Error()))
 		return ctrl.Result{}, err
 	}
+	// Build sorted endpoint list for deterministic condition message
+	endpointStrs := make([]string, 0, len(instance.Spec.Endpoints))
+	for _, k := range slices.Sorted(maps.Keys(instance.Spec.Endpoints)) {
+		endpointStrs = append(endpointStrs, k+":"+instance.Spec.Endpoints[k])
+	}
 	instance.Status.Conditions.MarkTrue(
 		keystonev1.KeystoneServiceOSEndpointsReadyCondition,
 		keystonev1.KeystoneServiceOSEndpointsReadyMessage,
-		instance.Spec.Endpoints,
+		endpointStrs,
 	)
 
 	Log.Info("Reconciled Endpoint normal successfully")
@@ -463,7 +469,7 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 	// delete endpoint if it does no longer exist in Spec.Endpoints
 	// but has a reference in Status.EndpointIDs
 	if instance.Status.EndpointIDs != nil {
-		for endpointType := range instance.Status.EndpointIDs {
+		for _, endpointType := range slices.Sorted(maps.Keys(instance.Status.EndpointIDs)) {
 			if _, ok := instance.Spec.Endpoints[endpointType]; !ok {
 				// get the gopher availability mapping for the endpointInterface
 				availability, err := openstack.GetAvailability(endpointType)
@@ -496,7 +502,8 @@ func (r *KeystoneEndpointReconciler) reconcileEndpoints(
 	}
 
 	// create / update endpoints
-	for endpointType, endpointURL := range instance.Spec.Endpoints {
+	for _, endpointType := range slices.Sorted(maps.Keys(instance.Spec.Endpoints)) {
+		endpointURL := instance.Spec.Endpoints[endpointType]
 
 		// get the gopher availability mapping for the endpointType
 		availability, err := openstack.GetAvailability(endpointType)

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -61,7 +61,7 @@ var (
 )
 
 const (
-	timeout = time.Second * 45
+	timeout = time.Second * 60
 
 	SecretName = "test-osp-secret"
 


### PR DESCRIPTION
Sort all map iterations across `keystoneapi` and `keystoneendpoint` controllers using `slices.Sorted(maps.Keys(...))` to prevent non-deterministic condition messages and unnecessary reconciliations.

Jira: https://redhat.atlassian.net/browse/OSPRH-28638