### PR TITLE
Replace hardcoded namespace in KUTTL tests with $NAMESPACE variable

### DIFF
--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -32,7 +32,6 @@ spec:
       memory: 500Mi
   secret: osp-secret
 status:
-  databaseHostname: openstack.keystone-kuttl-tests.svc
   readyCount: 1
 ---
 apiVersion: apps/v1
@@ -141,12 +140,21 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      # Verify databaseHostname matches the expected namespace-based pattern
+      dbHostTemplate='{{.status.databaseHostname}}'
+      dbHostname=$(oc get -n $NAMESPACE KeystoneAPI keystone -o go-template="$dbHostTemplate")
+      expectedDbHostname="openstack.$NAMESPACE.svc"
+      if [ "$dbHostname" != "$expectedDbHostname" ]; then
+        echo "databaseHostname mismatch: got '$dbHostname', expected '$expectedDbHostname'"
+        exit 1
+      fi
+
       # the actual addresses of the apiEndpoints are platform specific, so we can't rely on
       # kuttl asserts to check them. This short script gathers the addresses and checks that
       # the three endpoints are defined and their addresses follow the default pattern
       template='{{.status.apiEndpoints.internal}}{{":"}}{{.status.apiEndpoints.public}}{{"\n"}}'
       regex="http:\/\/keystone-internal.$NAMESPACE.*:http:\/\/keystone-public.$NAMESPACE.*"
-      apiEndpoints=$(oc get -n $NAMESPACE KeystoneAPI  keystone -o go-template="$template")
+      apiEndpoints=$(oc get -n $NAMESPACE KeystoneAPI keystone -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0

--- a/test/kuttl/common/scripts/rotate_token.sh
+++ b/test/kuttl/common/scripts/rotate_token.sh
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: keystone
-    namespace: keystone-kuttl-tests
+    namespace: $NAMESPACE
     annotations:
         keystone.openstack.org/rotatedat: "2009-11-10T23:00:00Z"
 EOF

--- a/test/kuttl/common/scripts/test_invalid_token.sh
+++ b/test/kuttl/common/scripts/test_invalid_token.sh
@@ -3,7 +3,7 @@ set -x
 
 export OS_TOKEN=$(cat /tmp/temporary_test_token)
 
-output=$(oc exec -tn $NAMESPACE openstackclient -- env -u OS_CLOUD - OS_AUTH_URL=http://keystone-public.keystone-kuttl-tests.svc:5000 OS_AUTH_TYPE=token OS_TOKEN=$OS_TOKEN openstack endpoint list 2>&1)
+output=$(oc exec -tn $NAMESPACE openstackclient -- env -u OS_CLOUD - OS_AUTH_URL=http://keystone-public.$NAMESPACE.svc:5000 OS_AUTH_TYPE=token OS_TOKEN=$OS_TOKEN openstack endpoint list 2>&1)
 
 filtered_output=$(echo "$output" | grep -i "Could not recognize Fernet token")
 

--- a/test/kuttl/common/scripts/validate_test_token.sh
+++ b/test/kuttl/common/scripts/validate_test_token.sh
@@ -17,7 +17,7 @@ sleep 60
 
 export OS_TOKEN=$(cat /tmp/temporary_test_token)
 
-output=$(oc exec -tn $NAMESPACE openstackclient -- env -u OS_CLOUD - OS_AUTH_URL=http://keystone-public.keystone-kuttl-tests.svc:5000 OS_AUTH_TYPE=token OS_TOKEN=$OS_TOKEN openstack endpoint list 2>&1 || true)
+output=$(oc exec -tn $NAMESPACE openstackclient -- env -u OS_CLOUD - OS_AUTH_URL=http://keystone-public.$NAMESPACE.svc:5000 OS_AUTH_TYPE=token OS_TOKEN=$OS_TOKEN openstack endpoint list 2>&1 || true)
 
 if echo "$output" | grep -qi "Could not recognize Fernet token"; then
     exit 1

--- a/test/kuttl/tests/keystone_scale/03-assert.yaml
+++ b/test/kuttl/tests/keystone_scale/03-assert.yaml
@@ -29,8 +29,18 @@ spec:
       cpu: "1"
       memory: 500Mi
   secret: osp-secret
-status:
-  databaseHostname: openstack.keystone-kuttl-tests.svc
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      dbHostTemplate='{{.status.databaseHostname}}'
+      dbHostname=$(oc get -n $NAMESPACE KeystoneAPI keystone -o go-template="$dbHostTemplate")
+      expectedDbHostname="openstack.$NAMESPACE.svc"
+      if [ "$dbHostname" != "$expectedDbHostname" ]; then
+        echo "databaseHostname mismatch: got '$dbHostname', expected '$expectedDbHostname'"
+        exit 1
+      fi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test/kuttl/tests/keystone_tls/01-assert.yaml
+++ b/test/kuttl/tests/keystone_tls/01-assert.yaml
@@ -17,7 +17,6 @@ spec:
         secretName: cert-keystone-public-svc
     caBundleSecretName: combined-ca-bundle
 status:
-  databaseHostname: openstack.keystone-kuttl-tests.svc
   readyCount: 1
 ---
 apiVersion: apps/v1
@@ -124,6 +123,15 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      # Verify databaseHostname matches the expected namespace-based pattern
+      dbHostTemplate='{{.status.databaseHostname}}'
+      dbHostname=$(oc get -n $NAMESPACE KeystoneAPI keystone -o go-template="$dbHostTemplate")
+      expectedDbHostname="openstack.$NAMESPACE.svc"
+      if [ "$dbHostname" != "$expectedDbHostname" ]; then
+        echo "databaseHostname mismatch: got '$dbHostname', expected '$expectedDbHostname'"
+        exit 1
+      fi
+
       # the actual addresses of the apiEndpoints are platform specific, so we can't rely on
       # kuttl asserts to check them. This short script gathers the addresses and checks that
       # the three endpoints are defined and their addresses follow the default pattern


### PR DESCRIPTION
KEYSTONE_KUTTL_NAMESPACE is user-configurable in install_yamls (via ?= assignment), but test scripts and asserts had "keystone-kuttl-tests" hardcoded in service hostnames, secret metadata, and databaseHostname assertions. Tests would fail when run with a non-default namespace.

Replace all hardcoded namespace references with the $NAMESPACE env var that KUTTL provides to test scripts. For databaseHostname validation, switch from static YAML asserts to script-based checks that dynamically construct the expected value.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>