### PR TITLE
Custom httpd configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ either by DNS or via /etc/hosts:
 +--------------+-----------+-----------------------------------------------------------------+
 ```
 
+## Customize httpd
+
+- [Customize httpd](config/samples/httpd-overrides): inject custom httpd
+  configuration through extraMounts interface
+
 # Design
 The current design takes care of the following:
 

--- a/config/samples/httpd-overrides/README.md
+++ b/config/samples/httpd-overrides/README.md
@@ -1,0 +1,121 @@
+# Keystone HTTPD Configuration Overrides
+
+The keystone-operator provides mechanisms to customize the Apache HTTPD server
+configuration through the use of custom configuration files. This feature
+leverages the
+[ExtraMounts](https://github.com/openstack-k8s-operators/dev-docs/blob/main/extra_mounts.md)
+functionality to mount custom HTTPD configuration files into the Keystone
+deployment.
+
+## How It Works
+
+1. **Custom Configuration Files**: Create HTTPD configuration files with your
+   custom settings
+2. **ConfigMap**: Create ConfigMaps from files containing the overrides
+3. **OpenStackControlPlane Patch**: Patch the control plane to mount the
+   generated ConfigMap into Keystone containers. The HTTPD configuration
+   automatically includes files mounted to `/etc/httpd/conf_custom/*.conf`
+
+
+### Step 1: Create Custom HTTPD Configuration
+
+Create your custom HTTPD configuration file(s). As a best practice the filename
+could start with the `httpd_custom_` prefix, but all `*.conf` files mounted to
+`/etc/httpd/conf_custom/` are automatically included by the `IncludeOptional`
+directive in the base `httpd` configuration.
+
+Example (`httpd_custom_timeout.conf`):
+```apache
+# Custom timeout settings for Keystone
+Timeout 300
+KeepAliveTimeout 15
+```
+
+### Step 2. Create a ConfigMap
+
+Create a Kubernetes `ConfigMap` containing your custom configuration files:
+
+```bash
+oc create configmap httpd-overrides --from-file=httpd_custom_timeout.conf
+```
+
+It is possible to add multiple configuration files containing dedicated
+configuration directives:
+
+```bash
+oc create configmap httpd-overrides \
+  --from-file=httpd_custom_timeout.conf \
+  --from-file=httpd_custom_security.conf \
+  --from-file=httpd_custom_logging.conf
+```
+
+The following example is based on a single customization file and demonstrates
+how to set custom `Timeout` and `KeepAliveTimeout` parameters.
+
+### Step 3: Configure ExtraMounts in the OpenStackControlPlane
+
+Update your `OpenStackControlPlane` resource to include the custom HTTPD
+configuration files using `extraMounts`. The simplest approach is to mount
+the entire ConfigMap to the target `/etc/httpd/conf_custom` mount point:
+
+```yaml
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  keystone:
+    template:
+      extraMounts:
+      - extraVol:
+        - extraVolType: httpd-overrides
+          mounts:
+          - mountPath: /etc/httpd/conf_custom
+            name: httpd-overrides
+            readOnly: true
+          volumes:
+          - configMap:
+              name: httpd-overrides
+            name: httpd-overrides
+```
+
+## Common Use Cases
+
+- **Timeout Adjustments**: Modify request timeout values for specific environments
+- **Security Headers**: Add custom security headers or configurations
+- **Logging**: Customize Apache logging configuration
+- **Performance Tuning**: Adjust worker processes, connection limits, etc.
+
+## Verification
+
+After deploying your custom `HTTPD` configuration, you can verify that the
+settings have been properly applied:
+
+### 1. Find the Keystone Pod
+
+First, identify the running Keystone pod:
+
+```bash
+$ oc get pods -l service=keystone
+```
+
+### 2. Verify Configuration Loading
+
+Connect to the Keystone Pod and check that your custom configuration has been
+loaded:
+
+```bash
+# Replace <keystone-pod-name> with the actual pod name from step 1
+oc rsh -c keystone-api <keystone-pod-name>
+# Inside the pod, dump the HTTPD configuration and check for your custom settings
+httpd -D DUMP_CONFIG
+```
+
+### 3. Additional Verification Commands
+
+You can also verify other aspects of the configuration:
+
+```bash
+# Check all loaded configuration files
+$ httpd -D DUMP_INCLUDES
+```

--- a/config/samples/httpd-overrides/httpd_custom_timeout.conf
+++ b/config/samples/httpd-overrides/httpd_custom_timeout.conf
@@ -1,0 +1,5 @@
+# Custom timeout settings for Keystone HTTPD
+# This file demonstrates how to override default timeout values
+# for Apache HTTPD serving Keystone API requests
+Timeout 300
+KeepAliveTimeout 15

--- a/config/samples/httpd-overrides/httpd_overrides.yaml
+++ b/config/samples/httpd-overrides/httpd_overrides.yaml
@@ -1,0 +1,18 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  keystone:
+    template:
+      extraMounts:
+        - extraVol:
+            - extraVolType: httpd-overrides
+              mounts:
+                - mountPath: /etc/httpd/conf_custom
+                  name: httpd-overrides
+                  readOnly: true
+              volumes:
+                - configMap:
+                    name: httpd-overrides
+                  name: httpd-overrides

--- a/config/samples/httpd-overrides/kustomization.yaml
+++ b/config/samples/httpd-overrides/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/openstack-k8s-operators/openstack-operator/main/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+
+patches:
+  - target:
+      kind: OpenStackControlPlane
+      name: .*
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: openstack
+  - path: httpd_overrides.yaml
+
+configMapGenerator:
+- files:
+  - ./httpd_custom_timeout.conf
+  name: httpd-overrides

--- a/templates/keystoneapi/config/httpd.conf
+++ b/templates/keystoneapi/config/httpd.conf
@@ -63,5 +63,7 @@ CustomLog /dev/stdout proxy env=forwarded
   Include conf/httpd_custom_{{ $endpt }}_*
 {{- end }}
 
+  IncludeOptional conf_custom/*.conf
+
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
Introduce a new sample demonstrating how to customize `httpd` conf using `extraMounts`. 
This approach leverages the `extraMounts` feature to inject custom configuration files loaded from `/etc/httpd/conf_custom`, enabling users to modify `httpd` settings without introducing new API parameters to the operator.
This follows the pattern already present in storage operators (e.g. https://github.com/openstack-k8s-operators/cinder-operator/pull/610)