### PR TITLE
ci: add openstack-meta-content-provider-master job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -26,3 +26,42 @@
       cifmw_test_operator_tempest_concurrency: 3
       cifmw_test_operator_tempest_include_list: |
         ^tempest.api.identity.
+
+- job:
+    name: keystone-openstack-meta-content-provider-master
+    parent: openstack-meta-content-provider-master
+    description: |
+      A meta content provider zuul job to build keystone
+      specific containers from OpenDev master.
+    vars:
+      cifmw_build_containers_force: false
+      cifmw_bop_dlrn_from_source: true
+      cifmw_build_containers_registry_namespace: podified-master-centos10
+      cifmw_operator_build_operators:
+        - name: keystone-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/keystone-operator"
+        - name: openstack-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+          image_base: keystone
+      cifmw_build_containers_image_tag: keystone_latest
+      cifmw_build_containers_exclude_containers:
+        master:
+          centos10:
+            - horizontest
+
+- job:
+    name: keystone-operator-tempest-master
+    parent: keystone-operator-tempest
+    dependencies:
+      - keystone-openstack-meta-content-provider-master
+    description: |
+      Deploy OpenStack with fresh keystone containers built from master.
+    extra-vars:
+      content_provider_dlrn_md5_hash: ''
+    vars:
+      cifmw_repo_setup_branch: master
+      fetch_dlrn_hash: false
+      cifmw_update_containers_openstack: true
+      cifmw_update_containers_org: podified-master-centos10
+      cifmw_update_containers_tag: keystone_latest
+      cifmw_test_operator_tempest_image_tag: keystone_latest

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,6 +3,12 @@
     name: openstack-k8s-operators/keystone-operator
     github-check:
       jobs:
+        # jobs using latest available code - local registry, tag: keystone_latest
+        - keystone-openstack-meta-content-provider-master:
+            voting: false
+        - keystone-operator-tempest-master:
+            voting: false
+        # jobs using latest stable code - tag: current-podified
         - openstack-k8s-operators-content-provider:
             vars:
               cifmw_install_yamls_sdk_version: v1.41.1


### PR DESCRIPTION
## Summary

- Add `keystone-openstack-meta-content-provider-master` job that builds fresh keystone containers from OpenDev master on each PR
- Add `keystone-operator-tempest-master` job that consumes those fresh containers
- Both jobs added to the `github-check` pipeline (tempest-master non-voting)

This allows co-submitting a keystone service fix and an operator change in a single review round, without waiting for the service fix to be packaged into `current-tested` first. Follows the pattern established by [telemetry-operator #894](https://github.com/openstack-k8s-operators/telemetry-operator/pull/894) and watcher-operator.

Jira: https://redhat.atlassian.net/browse/OSPRH-30892

Assisted-by: Claude Sonnet 4.6