### PR TITLE
Fix shell injection in trust_flush CronJob

### DIFF
--- a/api/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/api/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1611,6 +1611,7 @@ spec:
                 default: ""
                 description: TrustFlushArgs - Arguments added to keystone-manage trust_flush
                   command
+                pattern: ^[A-Za-z0-9 =._/-]*$
                 type: string
               trustFlushSchedule:
                 default: 1 * * * *

--- a/api/v1beta1/keystoneapi_types.go
+++ b/api/v1beta1/keystoneapi_types.go
@@ -115,6 +115,7 @@ type KeystoneAPISpecCore struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=""
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9 =._/-]*$`
 	// TrustFlushArgs - Arguments added to keystone-manage trust_flush command
 	TrustFlushArgs string `json:"trustFlushArgs"`
 

--- a/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
+++ b/config/crd/bases/keystone.openstack.org_keystoneapis.yaml
@@ -1611,6 +1611,7 @@ spec:
                 default: ""
                 description: TrustFlushArgs - Arguments added to keystone-manage trust_flush
                   command
+                pattern: ^[A-Za-z0-9 =._/-]*$
                 type: string
               trustFlushSchedule:
                 default: 1 * * * *

--- a/internal/keystone/cronjob.go
+++ b/internal/keystone/cronjob.go
@@ -16,6 +16,8 @@ limitations under the License.
 package keystone
 
 import (
+	"strings"
+
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -26,11 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// TrustFlushCommand -
-	TrustFlushCommand = "keystone-manage trust_flush"
-)
-
 // CronJob func
 func CronJob(
 	instance *keystonev1.KeystoneAPI,
@@ -39,7 +36,10 @@ func CronJob(
 	memcached *memcachedv1.Memcached,
 ) *batchv1.CronJob {
 
-	args := []string{"-c", TrustFlushCommand + instance.Spec.TrustFlushArgs}
+	cmd := []string{"keystone-manage", "trust_flush"}
+	if instance.Spec.TrustFlushArgs != "" {
+		cmd = append(cmd, strings.Fields(instance.Spec.TrustFlushArgs)...)
+	}
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
@@ -103,12 +103,9 @@ func CronJob(
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:  ServiceName + "-cron",
-									Image: instance.Spec.ContainerImage,
-									Command: []string{
-										"/bin/bash",
-									},
-									Args:            args,
+									Name:            ServiceName + "-cron",
+									Image:           instance.Spec.ContainerImage,
+									Command:         cmd,
 									Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 									VolumeMounts:    volumeMounts,
 									SecurityContext: baseSecurityContext(),


### PR DESCRIPTION
Replace the bash -c string concatenation of TrustFlushArgs with a direct argv array, preventing shell metacharacter injection. The CronJob now executes keystone-manage as Command: ["keystone-manage", "trust_flush", ...args] instead of Command: ["/bin/bash"] Args: ["-c", "keystone-manage trust_flush" + args].

Additionally add kubebuilder:validation:Pattern on the TrustFlushArgs CRD field to reject shell metacharacters at the API level.

Jira: [OSPRH-31632](https://redhat.atlassian.net/browse/OSPRH-31632)