### PR TITLE
Add transport URL secret rotation with consumer finalizer

### DIFF
--- a/api/v1beta1/keystoneapplicationcredential.go
+++ b/api/v1beta1/keystoneapplicationcredential.go
@@ -67,6 +67,8 @@ func (ac *KeystoneApplicationCredential) IsEDPMService() bool {
 	return ac.GetAnnotations()[EDPMServiceAnnotation] != "false"
 }
 
+// Deprecated: Use object.ManageSecretConsumerFinalizer and
+// object.FinalizeSecretRotation from lib-common instead.
 // ManageACSecretFinalizer ensures consumerFinalizer is present on the AC secret
 // identified by newSecretName and absent from the one identified by
 // oldSecretName. It is a no-op when both names are equal.
@@ -108,6 +110,7 @@ func ManageACSecretFinalizer(
 	return object.ManageConsumerFinalizer(ctx, h, newObj, oldObj, consumerFinalizer)
 }
 
+// Deprecated: Use object.RemoveSecretConsumerFinalizer from lib-common instead.
 // RemoveACSecretConsumerFinalizer removes consumerFinalizer from the AC secret
 // identified by secretName. It is a no-op when secretName is empty or the
 // secret no longer exists.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -253,9 +253,10 @@ func main() {
 	keystonev1.SetupDefaults()
 
 	if err := (&controller.KeystoneAPIReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Kclient: kclient,
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Kclient:   kclient,
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeystoneAPI")
 		os.Exit(1)

--- a/internal/controller/keystoneapi_controller.go
+++ b/internal/controller/keystoneapi_controller.go
@@ -42,6 +42,7 @@ import (
 	job "github.com/openstack-k8s-operators/lib-common/modules/common/job"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/object"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -96,8 +97,9 @@ func (r *KeystoneAPIReconciler) GetLogger(ctx context.Context) logr.Logger {
 // KeystoneAPIReconciler reconciles a KeystoneAPI object
 type KeystoneAPIReconciler struct {
 	client.Client
-	Kclient kubernetes.Interface
-	Scheme  *runtime.Scheme
+	Kclient   kubernetes.Interface
+	Scheme    *runtime.Scheme
+	APIReader client.Reader
 }
 
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;create;update;patch;delete
@@ -520,6 +522,32 @@ func (r *KeystoneAPIReconciler) reconcileDelete(ctx context.Context, instance *k
 		if err := db.DeleteFinalizer(ctx, helper); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+
+	if err := object.RemoveSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+		instance.Status.TransportURLSecret, keystone.TransportConsumerFinalizer); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// During a pending rotation, instance.Status.TransportURLSecret still
+	// points at the old secret while the consumer finalizer was already added
+	// to the new one (TransportURL CR's Status.SecretName). Clean that up too
+	// so the new secret doesn't get stuck in Terminating if later deleted.
+	transportURL := &rabbitmqv1.TransportURL{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      fmt.Sprintf("%s-keystone-transport", instance.Name),
+		Namespace: instance.Namespace,
+	}, transportURL)
+	if err == nil {
+		if transportURL.Status.SecretName != "" &&
+			transportURL.Status.SecretName != instance.Status.TransportURLSecret {
+			if err := object.RemoveSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+				transportURL.Status.SecretName, keystone.TransportConsumerFinalizer); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else if !k8s_errors.IsNotFound(err) {
+		return ctrl.Result{}, err
 	}
 
 	// Service is deleted so remove the finalizer.
@@ -1064,9 +1092,9 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 		Log.Info(fmt.Sprintf("TransportURL %s successfully reconciled - operation: %s", transportURL.Name, string(op)))
 	}
 
-	instance.Status.TransportURLSecret = transportURL.Status.SecretName
+	currentTransportSecret := transportURL.Status.SecretName
 
-	if instance.Status.TransportURLSecret == "" {
+	if currentTransportSecret == "" {
 		// Since the TransportURL secret is automatically created by the Infra operator,
 		// we treat this as an info (because the user is not responsible for manually creating it).
 		Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
@@ -1079,6 +1107,19 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	}
 	Log.Info(fmt.Sprintf("TransportURL secret name %s", transportURL.Status.SecretName))
 	instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
+
+	// Set status early for first-time setup so PatchInstance persists it
+	// even on early returns. During rotation (old != current), the status
+	// is only updated by FinalizeSecretRotation at end of reconcile.
+	if instance.Status.TransportURLSecret == "" ||
+		instance.Status.TransportURLSecret == currentTransportSecret {
+		instance.Status.TransportURLSecret = currentTransportSecret
+	}
+
+	if err := object.ManageSecretConsumerFinalizer(ctx, helper, instance.Namespace,
+		currentTransportSecret, keystone.TransportConsumerFinalizer); err != nil {
+		return ctrl.Result{}, err
+	}
 	// run check rabbitmq - end
 
 	//
@@ -1146,7 +1187,7 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	// - %-config configmap holding minimal keystone config required to get the service up, user can add additional files to be added to the service
 	// - parameters which has passwords gets added from the OpenStack secret via the init container
 	//
-	customConfigKeys, err := r.generateServiceConfigMaps(ctx, instance, helper, &configMapVars, memcached, db)
+	customConfigKeys, err := r.generateServiceConfigMaps(ctx, instance, helper, &configMapVars, memcached, db, currentTransportSecret)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -1228,13 +1269,9 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
-	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
+	inputHash, _, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
 	if err != nil {
 		return ctrl.Result{}, err
-	} else if hashChanged {
-		// Hash changed and instance status should be updated (which will be done by main defer func),
-		// so we need to return and reconcile again
-		return ctrl.Result{}, nil
 	}
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
@@ -1408,15 +1445,18 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 		return ctrl.Result{}, err
 	}
 
-	// Mark the Deployment as Ready only if the number of Replicas is equals
-	// to the Deployed instances (ReadyCount), and the the Status.Replicas
-	// match Status.ReadyReplicas. If a deployment update is in progress,
-	// Replicas > ReadyReplicas.
-	// In addition, make sure the controller sees the last Generation
-	// by comparing it with the ObservedGeneration.
+	ready := false
 	if deployment.IsReady(deploy) {
+		ready, err = deployment.IsReadyForInput(ctx, r.APIReader,
+			types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace},
+			inputHash)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	if ready {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
-	} else {
+	} else if *instance.Spec.Replicas > 0 {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.RequestedReason,
@@ -1459,6 +1499,36 @@ func (r *KeystoneAPIReconciler) reconcileNormal(
 	//
 	err = r.reconcileCloudConfig(ctx, helper, instance)
 	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Guard the rotation on the sub-conditions computed during this reconcile,
+	// not instance.IsReady(): the Ready condition is reset to Unknown by
+	// Conditions.Init() at the top of every reconcile and only recomputed in
+	// the deferred PatchInstance, so IsReady() would always be false here.
+	guardReady := instance.Status.Conditions.AllSubConditionIsTrue()
+	transportSecretName, err := object.FinalizeSecretRotation(
+		ctx, helper, instance.Namespace,
+		instance.Status.TransportURLSecret,
+		currentTransportSecret,
+		keystone.TransportConsumerFinalizer,
+		guardReady,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	instance.Status.TransportURLSecret = transportSecretName
+
+	// Self-heal consumer finalizers stranded on secrets superseded during
+	// rapid rotation (A -> B -> C before the workload became ready):
+	// FinalizeSecretRotation only ever releases the single tracked "old"
+	// secret, so any intermediate secret's finalizer would otherwise leak.
+	// keep enumerates every secret that legitimately still holds the
+	// finalizer; all others in the namespace are pruned.
+	if err := object.PruneSecretConsumerFinalizers(
+		ctx, helper, instance.Namespace, keystone.TransportConsumerFinalizer,
+		instance.Status.TransportURLSecret, currentTransportSecret,
+	); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -1514,6 +1584,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	envVars *map[string]env.Setter,
 	mc *memcachedv1.Memcached,
 	db *mariadbv1.Database,
+	transportURLSecretName string,
 ) ([]string, error) {
 	//
 	// create Configmap/Secret required for keystone input
@@ -1538,7 +1609,7 @@ func (r *KeystoneAPIReconciler) generateServiceConfigMaps(
 	}
 	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
-	transportURLSecret, _, err := oko_secret.GetSecret(ctx, h, instance.Status.TransportURLSecret, instance.Namespace)
+	transportURLSecret, _, err := oko_secret.GetSecret(ctx, h, transportURLSecretName, instance.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/keystone/const.go
+++ b/internal/keystone/const.go
@@ -52,6 +52,8 @@ const (
 	FederationDefaultMountPath = "/var/lib/httpd/metadata"
 	// VarLogKeystoneVolumeName - name of the writable emptyDir volume mounted at /var/log/keystone
 	VarLogKeystoneVolumeName = "var-log-keystone"
+	// TransportConsumerFinalizer is the finalizer added to transport URL secrets
+	TransportConsumerFinalizer = "openstack.org/keystone-transport-consumer"
 )
 
 // KeystonePropagation is the definition of the Keystone propagation service

--- a/test/functional/keystoneapi_controller_test.go
+++ b/test/functional/keystoneapi_controller_test.go
@@ -35,6 +35,7 @@ import (
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	keystoneinternal "github.com/openstack-k8s-operators/keystone-operator/internal/keystone"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
@@ -2791,6 +2792,157 @@ OIDCRedirectURI "{{ .KeystoneEndpointPublic }}/v3/auth/OS-FEDERATION/websso/open
 			err := k8sClient.Create(ctx, obj)
 			Expect(err).To(HaveOccurred(), "Expected creation to fail due to validation constraint")
 			Expect(err.Error()).To(ContainSubstring("gracePeriodDays must be smaller than expirationDays"))
+		})
+	})
+
+	When("TransportURL consumer finalizer is managed", func() {
+		BeforeEach(func() {
+			DeferCleanup(th.DeleteInstance, CreateKeystoneAPI(keystoneAPIName, GetDefaultKeystoneAPISpec()))
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateKeystoneMessageBusSecret(namespace, "rabbitmq-secret"))
+			DeferCleanup(
+				k8sClient.Delete, ctx, CreateKeystoneAPISecret(namespace, SecretName))
+			DeferCleanup(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
+					namespace,
+					GetKeystoneAPI(keystoneAPIName).Spec.DatabaseInstance,
+					corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Port: 3306}},
+					},
+				),
+			)
+			mariadb.SimulateMariaDBAccountCompleted(keystoneAccountName)
+			mariadb.SimulateMariaDBDatabaseCompleted(keystoneDatabaseName)
+			infra.SimulateTransportURLReady(types.NamespacedName{
+				Name:      fmt.Sprintf("%s-keystone-transport", keystoneAPIName.Name),
+				Namespace: namespace,
+			})
+			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, "memcached", memcachedSpec))
+			infra.SimulateMemcachedReady(types.NamespacedName{
+				Name:      "memcached",
+				Namespace: namespace,
+			})
+			th.SimulateJobSuccess(dbSyncJobName)
+			th.SimulateJobSuccess(bootstrapJobName)
+			th.SimulateDeploymentReplicaReady(deploymentName)
+		})
+
+		It("should add the consumer finalizer to the transport secret", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "rabbitmq-secret",
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should remove the consumer finalizer from transport secret on CR deletion", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "rabbitmq-secret",
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			th.DeleteInstance(GetKeystoneAPI(keystoneAPIName))
+
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      "rabbitmq-secret",
+				})
+				g.Expect(secret.Finalizers).NotTo(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should move the finalizer from the old to the new secret on transport rotation", func() {
+			oldSecretName := "rabbitmq-secret"
+
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      oldSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			// Wait for keystone to reach fully ready state
+			Eventually(func(g Gomega) {
+				instance := GetKeystoneAPI(keystoneAPIName)
+				g.Expect(instance.Status.Conditions.IsTrue(condition.ReadyCondition)).To(BeTrue())
+				g.Expect(instance.Status.TransportURLSecret).To(Equal(oldSecretName))
+			}, timeout, interval).Should(Succeed())
+
+			newSecretName := "rabbitmq-secret-rotated"
+
+			// Create the new rotated secret with different content
+			newSecret := th.CreateSecret(
+				types.NamespacedName{
+					Namespace: namespace,
+					Name:      newSecretName,
+				},
+				map[string][]byte{
+					"transport_url": []byte("rabbit://rotated-user:rotated-pass@rabbitmq/fake"),
+				},
+			)
+			DeferCleanup(k8sClient.Delete, ctx, newSecret)
+
+			// Simulate transport rotation: update TransportURL status with new secret name
+			transportURLName := types.NamespacedName{
+				Name:      fmt.Sprintf("%s-keystone-transport", keystoneAPIName.Name),
+				Namespace: namespace,
+			}
+			Eventually(func(g Gomega) {
+				transport := infra.GetTransportURL(transportURLName)
+				transport.Status.SecretName = newSecretName
+				g.Expect(k8sClient.Status().Update(ctx, transport)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			// Verify finalizer is added to the new secret
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      newSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			// The old secret's finalizer should NOT be removed yet -- deployment
+			// is re-deploying with new credentials and is not ready
+			Consistently(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      oldSecretName,
+				})
+				g.Expect(secret.Finalizers).To(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, "3s", interval).Should(Succeed())
+
+			// Simulate deployment becoming ready with the new credentials
+			Eventually(func(g Gomega) {
+				th.SimulateDeploymentReplicaReady(deploymentName)
+				// Verify old finalizer is removed
+				secret := th.GetSecret(types.NamespacedName{
+					Namespace: namespace,
+					Name:      oldSecretName,
+				})
+				g.Expect(secret.Finalizers).NotTo(
+					ContainElement(keystoneinternal.TransportConsumerFinalizer))
+			}, timeout, interval).Should(Succeed())
+
+			// Verify status tracks the new secret
+			Eventually(func(g Gomega) {
+				instance := GetKeystoneAPI(keystoneAPIName)
+				g.Expect(instance.Status.TransportURLSecret).To(Equal(newSecretName))
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 })

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -190,9 +190,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.KeystoneAPIReconciler{
-		Client:  k8sManager.GetClient(),
-		Scheme:  k8sManager.GetScheme(),
-		Kclient: kclient,
+		Client:    k8sManager.GetClient(),
+		Scheme:    k8sManager.GetScheme(),
+		Kclient:   kclient,
+		APIReader: k8sManager.GetAPIReader(),
 	}).SetupWithManager(context.Background(), k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## What this does

When infra-operator rotates a RabbitMQ transport URL (creating a new secret and user), consumer operators must hold a **consumer finalizer** on the old secret until all their pods have rolled out with the new credentials. Without this, infra-operator cleans up the old RabbitMQ user while pods are still connected with the old credentials, causing message-bus outages.

## Approach (updated)

> **Note:** this PR was reworked from the original grace-period design to an event-driven "applied input hash" design. The old approach released the finalizer after a fixed grace period based on the parent `Ready` condition, which was racy against the informer cache and could revoke credentials prematurely. The new approach releases the finalizer only once every child has provably rolled out.

1. Add a consumer finalizer to the current transport URL secret early in reconcile. `Status.TransportURLSecret` is set for first-time setup only (empty or unchanged); during rotation the status is updated solely by `FinalizeSecretRotation` at the end of reconcile.

2. Pass `transportURL.Status.SecretName` directly to sub-CR creation and config generation as a parameter — never read `Status.TransportURLSecret` for sub-CR specs.

3. Each child controller records an `AppliedInputSecretHash` in its status, set only after `statefulset.IsReadyForInput` / `deployment.IsReadyForInput` confirms — via an uncached API read — that the workload is fully rolled out with the expected `CONFIG_HASH`.

4. The parent mirrors a child's Ready condition only when its `Generation == ObservedGeneration` and `AppliedInputSecretHash` matches the current input hash; otherwise it sets the condition to Unknown.

5. Guard: `FinalizeSecretRotation` removes the consumer finalizer from the old secret only when every child reports the expected hash and is ready. The guard is computed from `Conditions.AllSubConditionIsTrue()` (not `IsReady()`), because `Conditions.Init()` resets the `Ready` condition to Unknown on every reconcile.

The same pattern applies to notification transport URL secrets and application-credential secrets where applicable.

## Dependency

Depends on the lib-common `IsReadyForInput` / `FinalizeSecretRotation` helpers (currently pinned via a `replace` to the fork commit while the lib-common PR is in review).
