### PR TITLE
Fix client IP logging in Keystone API VirtualHost

### DIFF
--- a/templates/keystoneapi/config/httpd.conf
+++ b/templates/keystoneapi/config/httpd.conf
@@ -41,7 +41,9 @@ CustomLog /dev/stdout proxy env=forwarded
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32109](https://redhat.atlassian.net/browse/OSPRH-32109)