### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/keystoneapi_webhook.go
+++ b/api/v1beta1/keystoneapi_webhook.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -53,8 +52,6 @@ func SetupKeystoneAPIDefaults(defaults KeystoneAPIDefaults) {
 
 	keystoneapilog.Info("KeystoneAPI defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &KeystoneAPI{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *KeystoneAPI) Default() {
@@ -83,8 +80,6 @@ func (spec *KeystoneAPISpecCore) Default() {
 	// Migration from deprecated fields is handled by openstack-operator
 	// This ensures users make a conscious choice about which cluster to use for notifications
 }
-
-var _ webhook.Validator = &KeystoneAPI{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *KeystoneAPI) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)