### PR TITLE
Restore pods RBAC needed for NetworkAttachments verification

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets/finalizers
   verbs:
   - create

--- a/internal/controller/keystoneapi_controller.go
+++ b/internal/controller/keystoneapi_controller.go
@@ -125,6 +125,7 @@ type KeystoneAPIReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // keystone service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 
 // Reconcile reconcile keystone API requests
 func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {


### PR DESCRIPTION
Commit 2adbb94 ("Remove unnecessary pods RBAC permissions") dropped the pods kubebuilder RBAC marker from keystoneapi_controller.go, which calls lib-common's VerifyNetworkStatusFromAnnotation to verify NetworkAttachments. That function lists Pods using the controller-manager's own client, so the manager's ClusterRole (config/rbac/role.yaml) needs get;list on pods or KeystoneAPI gets stuck in NetworkAttachmentsReady=False with a "pods is forbidden" error, as seen on manila/cinder/neutron-operator after the same cleanup. Restore the get;list marker and regenerate config/rbac/role.yaml. The unused rbacRules grant on the workload service account remains removed, since that really is unused.