### PR TITLE
[18-stable] Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   - services
   verbs:
@@ -26,6 +25,13 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/keystoneapi_controller.go
+++ b/internal/controller/keystoneapi_controller.go
@@ -125,7 +125,7 @@ type KeystoneAPIReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // keystone service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 
 // Reconcile reconcile keystone API requests
 func (r *KeystoneAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -548,11 +548,6 @@ func (r *KeystoneAPIReconciler) reconcileInit(
 			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)


### PR DESCRIPTION
The workload rbacRules and the matching kubebuilder RBAC marker in the controller granted the workload service account full CRUD (create/delete/get/list/patch/update/watch) on core Pods, but that service account never reads or writes Pod objects directly. Remove the unused grants.

The kubebuilder RBAC marker for pods (get;list) is kept: lib-common's VerifyNetworkStatusFromAnnotation, called from this controller to verify NetworkAttachments, lists Pods using the controller-manager's own client, so the manager's ClusterRole (config/rbac/role.yaml) still needs get;list on pods. Regenerate config/rbac/role.yaml.

Includes ef1e3b5cad2396845988b631390067954227eaf7


(cherry picked from commit 2adbb9411ddecb7af8d55f6992b09923c6065738)